### PR TITLE
Upgrade marked pkg 0.3.19 -> 3.0.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,9 @@ web_modules/
 .env.production.local
 .env.local
 
+# direnv environment files
+.envrc
+
 # parcel-bundler cache (https://parceljs.org/)
 .cache
 .parcel-cache

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,10 +28,117 @@
         "grunt-eslint": "^24.0.1",
         "grunt-rollup": "^12.0.0",
         "grunt-shell": "^4.0.0",
-        "load-grunt-tasks": "^5.1.0"
+        "load-grunt-tasks": "^5.1.0",
+        "puppeteer": "20.1.1"
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.21.4.tgz",
+      "integrity": "sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/highlight": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.18.6",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
+    },
+    "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -222,6 +329,37 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@puppeteer/browsers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.0.1.tgz",
+      "integrity": "sha512-9wkYhON9zBgtjYRE3FcokGCfjG25zjzNAYmsHpiWitRZ/4DeT3v125/fCUU66SaPJ4nUsxGNPgpS1TOcQ+8StA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "4.3.4",
+        "extract-zip": "2.0.1",
+        "http-proxy-agent": "5.0.0",
+        "https-proxy-agent": "5.0.1",
+        "progress": "2.0.3",
+        "proxy-from-env": "1.1.0",
+        "tar-fs": "2.1.1",
+        "unbzip2-stream": "1.4.3",
+        "yargs": "17.7.1"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.7.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/plugin-terser": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.1.tgz",
@@ -244,6 +382,15 @@
         }
       }
     },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -255,6 +402,23 @@
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
       "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
       "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "20.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.1.0.tgz",
+      "integrity": "sha512-O+z53uwx64xY7D6roOi4+jApDGFg0qn6WHcxe5QeqjMaTezBO/mxdfFXIVAVVyNWKx84OmPB3L8kbVYOTeN34A==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
@@ -294,6 +458,18 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/ajv": {
@@ -494,6 +670,26 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/basic-auth": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
@@ -511,6 +707,31 @@
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
       "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
       "dev": true
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/body": {
       "version": "5.1.0",
@@ -552,6 +773,39 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/buffer-from": {
@@ -602,6 +856,38 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true
+    },
+    "node_modules/chromium-bidi": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.7.tgz",
+      "integrity": "sha512-6+mJuFXwTMU6I3vYLs6IL8A1DyQTPjCfIL971X0aMPVGRbGnNfl6i6Cl0NMbxi2bRYLGESt9T2ZIMRM5PAEcIQ==",
+      "dev": true,
+      "dependencies": {
+        "mitt": "3.0.0"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/color-convert": {
@@ -700,6 +986,33 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
     },
+    "node_modules/cosmiconfig": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.1.3.tgz",
+      "integrity": "sha512-/UkO2JKI18b5jVMJUp0lvKFMpa/Gye+ZgZjKD+DGEN9y7NRcf/nK1A0sp67ONmKtnDCNMS44E6jrk0Yc3bDuUw==",
+      "dev": true,
+      "dependencies": {
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      }
+    },
+    "node_modules/cross-fetch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "dev": true,
+      "dependencies": {
+        "node-fetch": "2.6.7"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -790,6 +1103,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1120988",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1120988.tgz",
+      "integrity": "sha512-39fCpE3Z78IaIPChJsP6Lhmkbf4dWXOmzLk/KFTdRkNk/0JymRIfUynDVRndV9HoDz8PyalK1UH21ST/ivwW5Q==",
+      "dev": true
+    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -820,6 +1139,12 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "dev": true
     },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
     "node_modules/encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -845,6 +1170,15 @@
       "dev": true,
       "dependencies": {
         "string-template": "~0.2.1"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
       }
     },
     "node_modules/es-abstract": {
@@ -933,6 +1267,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-html": {
@@ -1276,6 +1619,26 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true
     },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1313,6 +1676,15 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "dependencies": {
+        "pend": "~1.2.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -1492,6 +1864,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1557,6 +1935,15 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
@@ -1569,6 +1956,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-symbol-description": {
@@ -2273,11 +2675,38 @@
       "integrity": "sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q==",
       "dev": true
     },
+    "node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/https-browserify": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
       "integrity": "sha512-EjDQFbgJr1vDD/175UJeSX3ncQ3+RUnCL5NkthQGHvF4VNHlzTy8ifJfTqz47qiPRqaFH58+CbuG3x51WuB1XQ==",
       "dev": true
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
@@ -2290,6 +2719,26 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/ignore": {
       "version": "5.2.4",
@@ -2394,6 +2843,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true
+    },
     "node_modules/is-bigint": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
@@ -2468,6 +2923,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -2723,6 +3187,12 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -2734,6 +3204,12 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -2814,6 +3290,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true
     },
     "node_modules/livereload-js": {
       "version": "2.4.0",
@@ -2971,6 +3453,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
+      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==",
+      "dev": true
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true
+    },
     "node_modules/morgan": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
@@ -3037,6 +3531,26 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-http2": {
@@ -3360,6 +3874,24 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parse-passwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
@@ -3431,6 +3963,21 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -3563,6 +4110,31 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
+    },
+    "node_modules/pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
@@ -3570,6 +4142,51 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/puppeteer": {
+      "version": "20.1.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-20.1.1.tgz",
+      "integrity": "sha512-agGDvDPIgYYwXL1WFP/O+HiDnFHJxtkmqyg4QOiHhgAgopyjOc+itL8SuXkJzXNSh9pnjGcZvl7ouJy/rU3SRg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@puppeteer/browsers": "1.0.1",
+        "cosmiconfig": "8.1.3",
+        "https-proxy-agent": "5.0.1",
+        "progress": "2.0.3",
+        "proxy-from-env": "1.1.0",
+        "puppeteer-core": "20.1.1"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "20.1.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-20.1.1.tgz",
+      "integrity": "sha512-iB9F2Om8J+nU4qi30oYw0hMWOw6eQN7kFkLLI/u3UvxONOCx5o0KmM6+byaK2/QGIuQu2ly1mPaJnC1DyoW07Q==",
+      "dev": true,
+      "dependencies": {
+        "@puppeteer/browsers": "1.0.1",
+        "chromium-bidi": "0.4.7",
+        "cross-fetch": "3.1.5",
+        "debug": "4.3.4",
+        "devtools-protocol": "0.0.1120988",
+        "extract-zip": "2.0.1",
+        "https-proxy-agent": "5.0.1",
+        "proxy-from-env": "1.1.0",
+        "tar-fs": "2.1.1",
+        "unbzip2-stream": "1.4.3",
+        "ws": "8.13.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.7.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/qs": {
@@ -3696,6 +4313,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -4125,6 +4751,20 @@
       "integrity": "sha512-Yptehjogou2xm4UJbxJ4CxgZx12HBfeystp0y3x7s4Dj32ltVVG1Gg8YhKjHZkHicuKpZX/ffilA8505VbUbpw==",
       "dev": true
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/string.prototype.trim": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz",
@@ -4227,6 +4867,48 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "dev": true,
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/terser": {
       "version": "5.17.1",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.1.tgz",
@@ -4249,6 +4931,12 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
     },
     "node_modules/timers-browserify": {
@@ -4306,6 +4994,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
     },
     "node_modules/tsconfig-paths": {
       "version": "3.14.2",
@@ -4376,6 +5070,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/unbzip2-stream": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
       }
     },
     "node_modules/unc-path-regex": {
@@ -4476,6 +5180,12 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
+    },
     "node_modules/websocket-driver": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
@@ -4511,6 +5221,27 @@
         "safe-buffer": "^5.1.2",
         "ws": "^3.2.0",
         "xtend": "^4.0.0"
+      }
+    },
+    "node_modules/websocket-stream/node_modules/ws": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+      "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+      "dev": true,
+      "dependencies": {
+        "async-limiter": "~1.0.0",
+        "safe-buffer": "~5.1.0",
+        "ultron": "~1.1.0"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -4573,6 +5304,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -4580,14 +5328,24 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-      "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
       "dev": true,
-      "dependencies": {
-        "async-limiter": "~1.0.0",
-        "safe-buffer": "~5.1.0",
-        "ultron": "~1.1.0"
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xtend": {
@@ -4597,6 +5355,52 @@
       "dev": true,
       "engines": {
         "node": ">=0.4"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "bootstrap": "^3.4.1",
         "jquery": "^3.6.3",
         "jquery-colorbox": "^1.6.4",
-        "marked": "3.0.1",
+        "marked": "4.0.19",
         "prismjs": "^1.29.0"
       },
       "devDependencies": {
@@ -3376,11 +3376,11 @@
       }
     },
     "node_modules/marked": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.1.tgz",
-      "integrity": "sha512-GQtec2MkSCp+ZecV2jBe7+J2fiDXeBFKUBr4981srZDjCaXg0WrtTo9eY2CVc2ZC5YQXkkc0Q8sTZ6c1DB1o2Q==",
+      "version": "4.0.19",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.19.tgz",
+      "integrity": "sha512-rgQF/OxOiLcvgUAj1Q1tAf4Bgxn5h5JZTp04Fx4XUkVhs7B+7YA9JEWJhJpoO8eJt8MkZMwqLCNeNqj1bCREZQ==",
       "bin": {
-        "marked": "bin/marked"
+        "marked": "bin/marked.js"
       },
       "engines": {
         "node": ">= 12"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "bootstrap": "^3.4.1",
         "jquery": "^3.6.3",
         "jquery-colorbox": "^1.6.4",
-        "marked": "1.2.8",
+        "marked": "3.0.1",
         "prismjs": "^1.29.0"
       },
       "devDependencies": {
@@ -3376,14 +3376,14 @@
       }
     },
     "node_modules/marked": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.8.tgz",
-      "integrity": "sha512-lzmFjGnzWHkmbk85q/ILZjFoHHJIQGF+SxGEfIdGk/XhiTPhqGs37gbru6Kkd48diJnEyYwnG67nru0Z2gQtuQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.1.tgz",
+      "integrity": "sha512-GQtec2MkSCp+ZecV2jBe7+J2fiDXeBFKUBr4981srZDjCaXg0WrtTo9eY2CVc2ZC5YQXkkc0Q8sTZ6c1DB1o2Q==",
       "bin": {
         "marked": "bin/marked"
       },
       "engines": {
-        "node": ">= 8.16.2"
+        "node": ">= 12"
       }
     },
     "node_modules/micromatch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "bootstrap": "^3.4.1",
         "jquery": "^3.6.3",
         "jquery-colorbox": "^1.6.4",
-        "marked": "^0.3.19",
+        "marked": "^0.8.2",
         "prismjs": "^1.29.0"
       },
       "devDependencies": {
@@ -2861,14 +2861,14 @@
       }
     },
     "node_modules/marked": {
-      "version": "0.3.19",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
-      "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
+      "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==",
       "bin": {
         "marked": "bin/marked"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">= 8.16.2"
       }
     },
     "node_modules/micromatch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "bootstrap": "^3.4.1",
         "jquery": "^3.6.3",
         "jquery-colorbox": "^1.6.4",
-        "marked": "^0.8.2",
+        "marked": "1.2.8",
         "prismjs": "^1.29.0"
       },
       "devDependencies": {
@@ -3376,9 +3376,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
-      "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.8.tgz",
+      "integrity": "sha512-lzmFjGnzWHkmbk85q/ILZjFoHHJIQGF+SxGEfIdGk/XhiTPhqGs37gbru6Kkd48diJnEyYwnG67nru0Z2gQtuQ==",
       "bin": {
         "marked": "bin/marked"
       },
@@ -4910,9 +4910,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.1.tgz",
-      "integrity": "sha512-hVl35zClmpisy6oaoKALOpS0rDYLxRFLHhRuDlEGTKey9qHjS1w9GMORjuwIMt70Wan4lwsLYyWDVnWgF+KUEw==",
+      "version": "5.17.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.2.tgz",
+      "integrity": "sha512-1D1aGbOF1Mnayq5PvfMc0amAR1y5Z1nrZaGCvI5xsdEfZEVte8okonk02OiaK5fw5hG1GWuuVsakOnpZW8y25A==",
       "dev": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,15 +34,39 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.1.tgz",
+      "integrity": "sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
-      "integrity": "sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.3.tgz",
+      "integrity": "sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.4.0",
+        "espree": "^9.5.2",
         "globals": "^13.19.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
@@ -55,6 +79,15 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "8.40.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.40.0.tgz",
+      "integrity": "sha512-ElyB54bJIhXQYVKjDSvCkPO1iU1tSAeVQJbllWJq1XQSmmA4dgFk8CbiBGpiOPxleE48vDogxCtmMYku4HSVLA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -91,9 +124,9 @@
       "dev": true
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
       "dev": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.0.1",
@@ -123,9 +156,9 @@
       }
     },
     "node_modules/@jridgewell/source-map": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
-      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.3.tgz",
+      "integrity": "sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg==",
       "dev": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.0",
@@ -133,20 +166,26 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.17",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
-      "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+      "version": "0.3.18",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
+      "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
       "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
+    },
+    "node_modules/@jridgewell/trace-mapping/node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -184,9 +223,9 @@
       }
     },
     "node_modules/@rollup/plugin-terser": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.0.tgz",
-      "integrity": "sha512-Ipcf3LPNerey1q9ZMjiaWHlNPEHNU/B5/uh9zXLltfEQ1lVSLLeZSgAtTPWGyw8Ip1guOeq+mDtdOlEj/wNxQw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.1.tgz",
+      "integrity": "sha512-aKS32sw5a7hy+fEXVy+5T95aDIwjpGHCTv833HXVtyKMDoVS7pBr5K3L9hEQoNqbJFjfANPrNpIXlTQ7is00eA==",
       "dev": true,
       "dependencies": {
         "serialize-javascript": "^6.0.0",
@@ -302,6 +341,19 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
+      "integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "is-array-buffer": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/array-differ": {
       "version": "3.0.0",
@@ -796,18 +848,18 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.1.tgz",
-      "integrity": "sha512-QudMsPOz86xYz/1dG1OuGBKOELjCh99IIWHLzy5znUB6j8xG2yMA7bfTV86VSqKF+Y/H08vQPR+9jyXpuC6hfg==",
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.2.tgz",
+      "integrity": "sha512-y/B5POM2iBnIxCiernH1G7rC9qQoM77lLIMQLuob0zhp8C56Po81+2Nj0WFKnd0pNReDTnkYryc+zhOzpEIROg==",
       "dev": true,
       "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
         "es-set-tostringtag": "^2.0.1",
         "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
         "function.prototype.name": "^1.1.5",
-        "get-intrinsic": "^1.1.3",
+        "get-intrinsic": "^1.2.0",
         "get-symbol-description": "^1.0.0",
         "globalthis": "^1.0.3",
         "gopd": "^1.0.1",
@@ -815,8 +867,8 @@
         "has-property-descriptors": "^1.0.0",
         "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.4",
-        "is-array-buffer": "^3.0.1",
+        "internal-slot": "^1.0.5",
+        "is-array-buffer": "^3.0.2",
         "is-callable": "^1.2.7",
         "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
@@ -824,11 +876,12 @@
         "is-string": "^1.0.7",
         "is-typed-array": "^1.1.10",
         "is-weakref": "^1.0.2",
-        "object-inspect": "^1.12.2",
+        "object-inspect": "^1.12.3",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.4",
         "regexp.prototype.flags": "^1.4.3",
         "safe-regex-test": "^1.0.0",
+        "string.prototype.trim": "^1.2.7",
         "string.prototype.trimend": "^1.0.6",
         "string.prototype.trimstart": "^1.0.6",
         "typed-array-length": "^1.0.4",
@@ -901,12 +954,15 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.34.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.34.0.tgz",
-      "integrity": "sha512-1Z8iFsucw+7kSqXNZVslXS8Ioa4u2KM7GPwuKtkTFAqZ/cHMcEaR+1+Br0wLlot49cNxIiZk5wp8EAbPcYZxTg==",
+      "version": "8.40.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.40.0.tgz",
+      "integrity": "sha512-bvR+TsP9EHL3TqNtj9sCNJVAFK3fBN8Q7g5waghxyRsPLIMwL73XSKnZFK0hk/O2ANC+iAoq6PWMQ+IfBAJIiQ==",
       "dev": true,
       "dependencies": {
-        "@eslint/eslintrc": "^1.4.1",
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.4.0",
+        "@eslint/eslintrc": "^2.0.3",
+        "@eslint/js": "8.40.0",
         "@humanwhocodes/config-array": "^0.11.8",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
@@ -916,11 +972,10 @@
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.1.1",
-        "eslint-utils": "^3.0.0",
-        "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.4.0",
-        "esquery": "^1.4.0",
+        "eslint-scope": "^7.2.0",
+        "eslint-visitor-keys": "^3.4.1",
+        "espree": "^9.5.2",
+        "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
@@ -941,7 +996,6 @@
         "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
-        "regexpp": "^3.2.0",
         "strip-ansi": "^6.0.1",
         "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0"
@@ -996,9 +1050,9 @@
       }
     },
     "node_modules/eslint-module-utils": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.4.tgz",
-      "integrity": "sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.8.0.tgz",
+      "integrity": "sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==",
       "dev": true,
       "dependencies": {
         "debug": "^3.2.7"
@@ -1072,9 +1126,9 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
-      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
+      "integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
       "dev": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -1082,53 +1136,32 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/eslint-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-      "dev": true,
-      "dependencies": {
-        "eslint-visitor-keys": "^2.0.0"
-      },
-      "engines": {
-        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      },
-      "peerDependencies": {
-        "eslint": ">=5"
-      }
-    },
-    "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
+      "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/espree": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
-      "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.2.tgz",
+      "integrity": "sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.8.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.3.0"
+        "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1151,9 +1184,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
       "dev": true,
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -2348,13 +2381,13 @@
       }
     },
     "node_modules/is-array-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.1.tgz",
-      "integrity": "sha512-ASfLknmY8Xa2XtB4wmbz13Wu202baeA18cJBCeCy0wXUHZF0IPyVEXqKEcd+t2fNSLLL1vC6k7lxZEojNbISXQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
+      "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.3",
+        "get-intrinsic": "^1.2.0",
         "is-typed-array": "^1.1.10"
       },
       "funding": {
@@ -2402,9 +2435,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
-      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
+      "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
       "dev": true,
       "dependencies": {
         "has": "^1.0.3"
@@ -2668,9 +2701,9 @@
       }
     },
     "node_modules/jquery": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.3.tgz",
-      "integrity": "sha512-bZ5Sy3YzKo9Fyc8wH2iIQK4JImJ6R0GWI9kL1/k7Z91ZBNgkRXE6U0JfHIizZbort8ZunhSI3jw9I6253ahKfg=="
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.4.tgz",
+      "integrity": "sha512-v28EW9DWDFpzcD9O5iyJXg3R3+q+mET5JhnjJzQUZMHOv67bpSIHq81GEYpPNZHG+XXHsfSme3nxp/hndKEcsQ=="
     },
     "node_modules/jquery-colorbox": {
       "version": "1.6.4",
@@ -2681,9 +2714,9 @@
       }
     },
     "node_modules/js-sdsl": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
-      "integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.0.tgz",
+      "integrity": "sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -3540,9 +3573,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.1.tgz",
+      "integrity": "sha512-0wsrzgTz/kAVIeuxSjnpGC56rzYtr6JT/2BwEvMaPhFIoYa1aGO8LbzuU1R0uUYQkLpWBTOj0l/CLAJB64J6nQ==",
       "dev": true,
       "dependencies": {
         "side-channel": "^1.0.4"
@@ -3622,9 +3655,9 @@
       "dev": true
     },
     "node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -3649,14 +3682,14 @@
       }
     },
     "node_modules/regexp.prototype.flags": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
-      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
+      "integrity": "sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "functions-have-names": "^1.2.2"
+        "define-properties": "^1.2.0",
+        "functions-have-names": "^1.2.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3665,25 +3698,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/regexpp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      }
-    },
     "node_modules/resolve": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
+      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
       "dev": true,
       "dependencies": {
-        "is-core-module": "^2.9.0",
+        "is-core-module": "^2.11.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -4104,6 +4125,23 @@
       "integrity": "sha512-Yptehjogou2xm4UJbxJ4CxgZx12HBfeystp0y3x7s4Dj32ltVVG1Gg8YhKjHZkHicuKpZX/ffilA8505VbUbpw==",
       "dev": true
     },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz",
+      "integrity": "sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/string.prototype.trimend": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
@@ -4190,9 +4228,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.16.3",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.3.tgz",
-      "integrity": "sha512-v8wWLaS/xt3nE9dgKEWhNUFP6q4kngO5B8eYFUuebsu7Dw/UNAnpUod6UHo04jSSkv8TzKHjZDSd7EXdDQAl8Q==",
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.1.tgz",
+      "integrity": "sha512-hVl35zClmpisy6oaoKALOpS0rDYLxRFLHhRuDlEGTKey9qHjS1w9GMORjuwIMt70Wan4lwsLYyWDVnWgF+KUEw==",
       "dev": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.2",
@@ -4270,13 +4308,13 @@
       }
     },
     "node_modules/tsconfig-paths": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
-      "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
+      "integrity": "sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==",
       "dev": true,
       "dependencies": {
         "@types/json5": "^0.0.29",
-        "json5": "^1.0.1",
+        "json5": "^1.0.2",
         "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "bootstrap": "^3.4.1",
     "jquery": "^3.6.3",
     "jquery-colorbox": "^1.6.4",
-    "marked": "^0.3.19",
+    "marked": "^0.8.2",
     "prismjs": "^1.29.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "grunt-eslint": "^24.0.1",
     "grunt-rollup": "^12.0.0",
     "grunt-shell": "^4.0.0",
-    "load-grunt-tasks": "^5.1.0"
+    "load-grunt-tasks": "^5.1.0",
+    "puppeteer": "20.1.1"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "bootstrap": "^3.4.1",
     "jquery": "^3.6.3",
     "jquery-colorbox": "^1.6.4",
-    "marked": "^0.8.2",
+    "marked": "1.2.7",
     "prismjs": "^1.29.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "bootstrap": "^3.4.1",
     "jquery": "^3.6.3",
     "jquery-colorbox": "^1.6.4",
-    "marked": "3.0.0",
+    "marked": "3.0.8",
     "prismjs": "^1.29.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "bootstrap": "^3.4.1",
     "jquery": "^3.6.3",
     "jquery-colorbox": "^1.6.4",
-    "marked": "1.2.7",
+    "marked": "3.0.0",
     "prismjs": "^1.29.0"
   }
 }

--- a/tests/crappy_tests/README.md
+++ b/tests/crappy_tests/README.md
@@ -1,0 +1,22 @@
+# Crappy Tests Are Better Than No Tests
+
+This project desparately needs better tests than it has if we want anyone to be
+able to help just a little vs. figuring out how everything is put together.
+
+Tests in this directory are an attempt to help with that, and might one day
+graduate to the main `tests` dir, but for now they're here ... and they're
+better than nothing, _if just barely._
+
+These were added by [Jim Meyer](https://github.com/purp) to help safely upgrade
+a node package dependency. Hopefully one day we'll have better tests. Until 
+then, see title above.
+
+## Current Crappy Testing Methodology
+
+1. **Update your baseline.** 
+  1. Switch to whatever branch/commit you want to compare to
+  1. Run `node fetch-pages.js`
+  1. Move the `*.html` files created to different names like `index.baseline.html` etc.
+1. **Generate current pages.**
+  1. Do the same as above in the branch/commit you want to test
+1. **Diff the output.** If they look clean, congrats! You haven't broken anything (that we know of ...)

--- a/tests/crappy_tests/cheatsheet.baseline-main.html
+++ b/tests/crappy_tests/cheatsheet.baseline-main.html
@@ -1,0 +1,783 @@
+<!DOCTYPE html><html class=""><!--
+   This is MDwiki v0.6.6 in debug mode
+   (C) 2013 by Timo Dörr and contributors. This software is licensed
+   under the terms of the GPLv3 with additional terms applied.
+   See https://github.com/Dynalon/mdwiki/blob/0.6.x/LICENSE.txt for more detail.
+   See https://github.com/Dynalon/mdwiki.git for a copy of the source code.
+--><head>
+    <title>MDwiki</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="fragment" content="!">
+    <link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
+    <meta charset="UTF-8">
+<link rel="stylesheet" href="node_modules/bootstrap/dist/css/bootstrap.css" type="text/css">
+<link rel="stylesheet" href="node_modules/prismjs/themes/prism.css" type="text/css">
+<link rel="stylesheet" href="node_modules/prismjs/plugins/previewers/prism-previewers.css" type="text/css">
+<link rel="stylesheet" href="src/lib/jquery-colorbox/css/colorbox.css" type="text/css">
+<link rel="stylesheet" href="src/css/mdwiki.css" type="text/css">
+<script type="text/javascript" src="node_modules/jquery/dist/jquery.js"></script>
+<script type="text/javascript" src="node_modules/bootstrap/dist/js/bootstrap.js"></script>
+<script type="text/javascript" src="node_modules/prismjs/prism.js"></script>
+<script type="text/javascript" src="src/_compiled/js/prism-ext.js"></script>
+<script type="text/javascript" src="node_modules/jquery-colorbox/jquery.colorbox.js"></script>
+<script type="text/javascript" src="node_modules/marked/lib/marked.js"></script>
+<script type="text/javascript" src="src/_compiled/js/mdwiki.js"></script>
+<script type="text/javascript">$.md.logThreshold = $.md.loglevel.DEBUG;</script>
+  </head>
+  <body>
+    <noscript>
+        This website requires Javascript to be enabled. Please turn on Javascript
+        and reload the page.
+    </noscript>
+
+    <div id="md-all"><div id="md-menu">
+
+<div id="md-main-navbar" class="navbar navbar-default navbar-fixed-top" role="navigation"><div class="navbar-header"><button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-ex1-collapse"><span class="sr-only">Toggle navigation</span><span class="icon-bar"></span><span class="icon-bar"></span><span class="icon-bar"></span></button><a class="navbar-brand" href="#"></a></div><div class="collapse navbar-collapse navbar-ex1-collapse"><ul class="nav navbar-nav"><ul class="nav navbar-nav navbar-right"></ul><li><a href="#!index.md">Index</a></li><li class="active"><a href="#!cheatsheet.md">Cheatsheet</a></li></ul></div></div></div><div class="container" id="md-body-container"><div class="row" id="md-body-row"><div id="md-body" style="margin-top: 60px;"><div class="container" id="md-title-container"><div class="row" id="md-title-row"><div id="md-title" class="col-md-12"><div class="page-header"><h1 id="cheatsheet---markdown-syntax-with-gfm">Cheatsheet - Markdown Syntax with GFM</h1></div></div></div></div><div class="container" id="md-menu-container"><div class="row" id="md-menu-row"></div></div><div class="container" id="md-content-container"><div class="row" id="md-content-row"><div id="md-content" class="col-md-12"><hr>
+<p><div class="md-text">title: Cheatsheet - Markdown Syntax with GFM MMM<br>description: Extended markdown syntax<br>tags:</div></p>
+<ul>
+<li>markadown</li>
+<li>extended</li>
+<li>gfm<br>Tags:</li>
+</ul>
+<hr>
+
+<p><div class="md-text">This cheatsheet uses markdown syntax based on:</div></p>
+<ul>
+<li><a href="http://daringfireball.net/projects/markdown/syntax">Markdown Specification</a></li>
+<li><a href="https://help.github.com/articles/github-flavored-markdown">Github Flavored Markdown</a></li>
+<li><a href="./#extensions">Markdown-it Parser Extensions</a></li>
+</ul>
+<h2 id="table-of-contents" class="md-inpage-anchor">Table of Contents<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Table_of_Contents">?</a></span></h2>
+<ul>
+<li>Markdown<ul>
+<li><a href="./#headers">Headers</a></li>
+<li><a href="./#paragraphs-and-line-breaks">Paragraphs and Line Breaks</a></li>
+<li><a href="./#styling-text">Styling Text</a><ul>
+<li><a href="./#escaping">Escaping</a></li>
+</ul>
+</li>
+<li><a href="./#lists">Lists</a><ul>
+<li><a href="./#unordered">Unordered</a></li>
+<li><a href="./#ordered-mixed">Ordered, Mixed</a></li>
+</ul>
+</li>
+<li><a href="./#tables">Tables</a><ul>
+<li><a href="./#column-alignment">Column Alignment</a></li>
+</ul>
+</li>
+<li><a href="./#links">Links</a><ul>
+<li><a href="./#link-within-document">Link within document</a></li>
+</ul>
+</li>
+<li><a href="./#block-quotes">Block Quotes</a></li>
+<li><a href="./#horizontal-ruler">Horizontal Ruler</a></li>
+<li><a href="./#images">Images</a></li>
+<li><a href="./#code">Code</a><ul>
+<li><a href="./#indented-block">Indented Block</a></li>
+<li><a href="./#highlighting">Highlighting</a></li>
+</ul>
+</li>
+<li><a href="./#inline-html">Inline HTML</a></li>
+<li><a href="./#inline-comments">Inline Comments</a></li>
+</ul>
+</li>
+<li><a href="./#extensions">Extensions</a><ul>
+<li><a href="./#styles">Styles</a></li>
+<li><a href="./#abbreviation">Abbreviation</a></li>
+<li><a href="./#admonitions">Admonitions</a></li>
+<li><a href="./#attributes">Attributes</a></li>
+<li><a href="./#definition-lists">Definition Lists</a></li>
+<li><a href="./#emoji">Emoji</a></li>
+<li><a href="./#footnotes">Footnotes</a></li>
+<li><a href="./#math-with-katex">Math with KaTeX</a></li>
+<li><a href="./#mark">Mark</a></li>
+<li><a href="./#multimarkdown-table-syntax">MultiMarkdown table syntax</a></li>
+<li><a href="./#subscript">Subscript</a></li>
+<li><a href="./#superscript">Superscript</a></li>
+<li><a href="./#tasklists">Tasklists</a></li>
+</ul>
+</li>
+<li><a href="./#preprocessor">Preprocessor</a><ul>
+<li><a href="./#include-other-files">Include other files</a></li>
+<li><a href="./#table-of-contents-1">Table of Contents</a></li>
+<li><a href="./#reference-list">Reference list</a></li>
+</ul>
+</li>
+</ul>
+<!-- toc (level=4) -->
+
+<h2 id="headers" class="md-inpage-anchor">Headers<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Headers">?</a></span></h2>
+<pre><code># h1
+
+## h2
+
+### h3
+
+#### h4
+
+##### h5
+
+###### h6
+
+h1 Alternate
+============
+
+h2 Alternate
+------------</code></pre><h1 id="h1" class="md-inpage-anchor">h1<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#h1">?</a></span></h1>
+<h2 id="h2" class="md-inpage-anchor">h2<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#h2">?</a></span></h2>
+<h3 id="h3" class="md-inpage-anchor">h3<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#h3">?</a></span></h3>
+<h4 id="h4" class="md-inpage-anchor">h4<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#h4">?</a></span></h4>
+<h5 id="h5" class="md-inpage-anchor">h5<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#h5">?</a></span></h5>
+<h6 id="h6" class="md-inpage-anchor">h6<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#h6">?</a></span></h6>
+<h1 id="h1-alternate" class="md-inpage-anchor">h1 Alternate<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#h1_Alternate">?</a></span></h1>
+<h2 id="h2-alternate" class="md-inpage-anchor">h2 Alternate<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#h2_Alternate">?</a></span></h2>
+<h2 id="paragraphs-and-line-breaks" class="md-inpage-anchor">Paragraphs and Line Breaks<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Paragraphs_and_Line_Breaks">?</a></span></h2>
+<pre><code>A paragraph is a paragraph is a paragraph is a paragraph is a paragraph. Is a paragraph is a paragraph is a paragraph is a paragraph is a paragraph. Is a paragraph is a paragraph is a paragraph.
+This is a not a new line.
+This as not as well..
+
+This is a new paragraph.
+
+Forcing a new line with `&lt;br&gt;` &lt;br&gt; causes a new line.
+
+Or ending a line with two spaces  
+causes a line break as well</code></pre><p><div class="md-text">A paragraph is a paragraph is a paragraph is a paragraph is a paragraph. Is a paragraph is a paragraph is a paragraph is a paragraph is a paragraph. Is a paragraph is a paragraph is a paragraph.<br>This is a not a new line.<br>This as not as well..</div></p>
+<p><div class="md-text">This is a new paragraph.</div></p>
+<p><div class="md-text">Forcing a new line with <code>&lt;br&gt;</code> <br> causes a new line.</div></p>
+<p><div class="md-text">Or ending a line with two spaces<br>causes a line-break as well</div></p>
+<h2 id="styling-text" class="md-inpage-anchor">Styling Text<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Styling_Text">?</a></span></h2>
+<pre><code>**Bold** Text      === __Bold__ Text
+*Emphasised* Text  === _Emphasised_ Text
+`monospaced` Text
+~~strikethrough~~ Text
+Wi*thin*Words   - but not -   Wi_thin_Words</code></pre><p><div class="md-text"><strong>Bold</strong> Text      === <strong>Bold</strong> Text</div></p>
+<p><div class="md-text"><em>Emphasised</em> Text  === <em>Emphasised</em> Text</div></p>
+<p><div class="md-text"><code>Monospaced</code> Text</div></p>
+<p><div class="md-text"><del>Strikethrough</del> Text</div></p>
+<p><div class="md-text">Wi<em>thin</em>Words   - but not -   Wi_thin_Words</div></p>
+<h3 id="escaping" class="md-inpage-anchor">Escaping<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Escaping">?</a></span></h3>
+<pre><code>\\   backslash
+\`   backtick
+\*   asterisk
+\_   underscore
+\{\}  curly braces
+\[\]  square brackets
+\(\)  parentheses
+\#   hash mark
+\+   plus sign
+\-   minus sign (hyphen)
+\.   dot
+\!   exclamation mark</code></pre><p><div class="md-text">\   backslash<br><br>`   backtick<br><br>*   asterisk<br><br>_   underscore<br><br>{}  curly braces<br><br>[]  square brackets<br><br>()  parentheses<br><br>#   hash mark<br><br>+   plus sign<br><br>-   minus sign (hyphen)<br><br>.   dot<br><br>!   exclamation mark</div></p>
+<h2 id="lists" class="md-inpage-anchor">Lists<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Lists">?</a></span></h2>
+<h3 id="unordered" class="md-inpage-anchor">Unordered<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Unordered">?</a></span></h3>
+<pre><code>* Cyan
+* Magenta
+* Yellow
+
+- Red
+- Green
+- Blue
+
++ Black
++ Gray
++ White
+
+* Cyan
+  * No Red
+  * Green
+    * Is a color
+      * like the grass
+  * Blue
+    * Another color
+    * like the sky
+* Magenta
+* Yellow</code></pre><ul>
+<li><p><div class="md-text">Cyan</div></p>
+</li>
+<li><p><div class="md-text">Magenta</div></p>
+</li>
+<li><p><div class="md-text">Yellow</div></p>
+</li>
+<li><p><div class="md-text">Red</div></p>
+</li>
+<li><p><div class="md-text">Green</div></p>
+</li>
+<li><p><div class="md-text">Blue</div></p>
+</li>
+<li><p><div class="md-text">Black</div></p>
+</li>
+<li><p><div class="md-text">Gray</div></p>
+</li>
+<li><p><div class="md-text">White</div></p>
+</li>
+<li><p><div class="md-text">Cyan</div></p>
+<ul>
+<li>No Red</li>
+<li>Green<ul>
+<li>Is a color<ul>
+<li>like the grass</li>
+</ul>
+</li>
+</ul>
+</li>
+<li>Blue<ul>
+<li>Another color</li>
+<li>like the sky</li>
+</ul>
+</li>
+</ul>
+</li>
+<li><p><div class="md-text">Magenta</div></p>
+</li>
+<li><p><div class="md-text">Yellow</div></p>
+</li>
+</ul>
+<h3 id="ordered-mixed" class="md-inpage-anchor">Ordered, Mixed<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Ordered,_Mixed">?</a></span></h3>
+<pre><code>1. Red
+2. Green
+3. Blue
+
+2. Black
+3. Grey
+1. White
+
+&lt;!--- --&gt;
+
+40. Cyan
+   1. RGB (0, 255, 255)
+   1. A color between green and blue
+      * Green
+      * Blue
+2. Magenta
+10. Yellow</code></pre><p class="alert alert-info"><div class="md-text"><span style="color: #f55;"><strong>Note</strong>: Wrong numbers get corrected into right order!</span></div></p>
+<ol>
+<li><p><div class="md-text">Red</div></p>
+</li>
+<li><p><div class="md-text">Green</div></p>
+</li>
+<li><p class="alert alert-info"><div class="md-text">Blue <span style="color: #f55;"><strong>Note:</strong> Counting continues with line-breaks</span></div></p>
+</li>
+<li><p><div class="md-text">Black</div></p>
+</li>
+<li><p><div class="md-text">Grey</div></p>
+</li>
+<li><p><div class="md-text">White</div></p>
+</li>
+</ol>
+<!--- -->
+
+<ol start="40">
+<li>Cyan <span style="color: #f55;"><strong>Note:</strong> Counting is restarted with 40 after &lt;!--- --&gt;</span><ol>
+<li>RGB (0, 255, 255)</li>
+<li>A color between green and blue<ul>
+<li>Green</li>
+<li>Blue</li>
+</ul>
+</li>
+</ol>
+</li>
+<li>Magenta</li>
+<li>Yellow</li>
+</ol>
+<h2 id="tables" class="md-inpage-anchor">Tables<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Tables">?</a></span></h2>
+<pre><code>| Column 1 | Column 2 | Column 3 |
+| ---      | ---      | ---      |
+| Row 1    | 1        | 2        |
+| Row 2    | 3        | 4        |</code></pre><table class="table table-bordered">
+<thead>
+<tr>
+<th>Column 1</th>
+<th>Column 2</th>
+<th>Column 3</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Row 1</td>
+<td>1</td>
+<td>2</td>
+</tr>
+<tr>
+<td>Row 2</td>
+<td>3</td>
+<td>4</td>
+</tr>
+</tbody></table>
+<h3 id="column-alignment" class="md-inpage-anchor">Column Alignment<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Column_Alignment">?</a></span></h3>
+<pre><code>| Left Aligned | Center Aligned | Right Aligned |
+| ---          | :---:          | ---:          |
+| Row 1        | 1              | 2             |
+| Row 2        | 3              | 4             |</code></pre><table class="table table-bordered">
+<thead>
+<tr>
+<th>Left Aligned</th>
+<th align="center">Center Aligned</th>
+<th align="right">Right Aligned</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Row 1</td>
+<td align="center">1</td>
+<td align="right">2</td>
+</tr>
+<tr>
+<td>Row 2</td>
+<td align="center">3</td>
+<td align="right">4</td>
+</tr>
+</tbody></table>
+<h2 id="links" class="md-inpage-anchor">Links<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Links">?</a></span></h2>
+<pre><code>http://example.com
+
+&lt;http://example.com&gt;
+
+[Linktext](http://example.com)
+
+[Reference][Referenced Link]
+
+[Referenced Link][]
+
+[Referenced Link]: http://example.com</code></pre><p><div class="md-text"><a href="http://example.com">http://example.com</a></div></p>
+<p><div class="md-text"><a href="http://example.com">http://example.com</a></div></p>
+<p><div class="md-text"><a href="http://example.com">Linktext</a></div></p>
+<p><div class="md-text"><a href="http://example.com">Reference</a></div></p>
+<p><div class="md-text"><a href="http://example.com">Referenced Link</a></div></p>
+<h3 id="link-within-document" class="md-inpage-anchor">Link within document<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Link_within_document">?</a></span></h3>
+<pre><code>&lt;a name="cross-reference"&gt;
+
+[Cross-Reference](#cross-reference)</code></pre><a name="cross-reference">
+
+</a><p><div class="md-text"><a name="cross-reference"></a><a href="./#cross-reference">Cross-Reference</a></div></p>
+<h2 id="block-quotes" class="md-inpage-anchor">Block Quotes<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Block_Quotes">?</a></span></h2>
+<pre><code>&gt; Block Quoted Text
+Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus. Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.
+
+&gt; Or line
+&gt; by line
+
+You need "text" to break block quotes
+
+&gt; Or with a
+&gt; &gt; nested quote
+
+&gt; line</code></pre><blockquote>
+<p><div class="md-text">Block Quoted Text<br>Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus. Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.</div></p>
+</blockquote>
+<blockquote>
+<p><div class="md-text">Or line<br>by line</div></p>
+</blockquote>
+<p><div class="md-text">You need "text" to break block quotes</div></p>
+<blockquote>
+<p><div class="md-text">Or with a</div></p>
+<blockquote>
+<p><div class="md-text">nested quote</div></p>
+</blockquote>
+</blockquote>
+<blockquote>
+<p><div class="md-text">line</div></p>
+</blockquote>
+<h2 id="horizontal-ruler" class="md-inpage-anchor">Horizontal Ruler<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Horizontal_Ruler">?</a></span></h2>
+<p><div class="md-text">Three or more Hyphens, Asterisks, Underscores</div></p>
+<pre><code>---
+
+***
+___
+</code></pre><hr>
+<hr>
+<hr>
+<h2 id="images" class="md-inpage-anchor">Images<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Images">?</a></span></h2>
+<style>
+img[alt=img100x] {width: 100px; border: 5px solid red; border-radius: 25%}
+</style>
+
+<pre><code>![Alt Text](img/Hyperlink-Wikipedia.svg.png)
+![Alt Text](img/Hyperlink-Wikipedia.svg.png "Optional Title")
+![Alt Text](http://placehold.it/150x100)
+![broken image](http://localhost/my-broken-image)</code></pre><p class="md-image-group row"><div class="col-sm-3"><a class="md-image-selfref cboxElement" href="./img/Hyperlink-Wikipedia.svg.png" title=""><img src="./img/Hyperlink-Wikipedia.svg.png" alt="Alt Text" class="img-responsive img-thumbnail"></a></div><div class="col-sm-3"><a class="md-image-selfref cboxElement" href="./img/Hyperlink-Wikipedia.svg.png" title="Optional Title"><img src="./img/Hyperlink-Wikipedia.svg.png" alt="Alt Text" title="Optional Title" class="img-responsive img-thumbnail"></a></div><div class="col-sm-3"><a class="md-image-selfref cboxElement" href="http://placehold.it/150x100" title=""><img src="http://placehold.it/150x100" alt="Alt Text" class="img-responsive img-thumbnail"></a></div><div class="col-sm-3"><a class="md-image-selfref cboxElement" href="http://localhost/my-broken-image" title=""><img src="http://localhost/my-broken-image" alt="broken image" class="img-responsive img-thumbnail"></a></div></p>
+<p><div class="md-text">Using plain html can be used to size images:</div></p>
+<pre class="language-html" tabindex="0"><code class="language-html"><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>img</span> <span class="token attr-name">src</span><span class="token attr-value"><span class="token punctuation attr-equals">=</span><span class="token punctuation">"</span>img/Hyperlink-Wikipedia.svg.png<span class="token punctuation">"</span></span> <span class="token attr-name">title</span><span class="token attr-value"><span class="token punctuation attr-equals">=</span><span class="token punctuation">"</span>Optional Title<span class="token punctuation">"</span></span> <span class="token attr-name">alt</span><span class="token attr-value"><span class="token punctuation attr-equals">=</span><span class="token punctuation">"</span>Alt Text<span class="token punctuation">"</span></span> <span class="token attr-name">style</span><span class="token attr-value"><span class="token punctuation attr-equals">=</span><span class="token punctuation">"</span>width: 50px;<span class="token punctuation">"</span></span><span class="token punctuation">&gt;</span></span></code></pre>
+<a class="md-image-selfref" href="./img/Hyperlink-Wikipedia.svg.png" title="Optional Title"><img src="./img/Hyperlink-Wikipedia.svg.png" title="Optional Title" alt="Alt Text" style="width: 50px;"></a>
+
+<p><div class="md-text">Styling images can also be done by hijacking on the <code>alt</code> attribute.</div></p>
+<pre class="language-html" tabindex="0"><code class="language-html"><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>style</span><span class="token punctuation">&gt;</span></span>
+img[alt=img100x] {width: 100px; border: 5px solid red; border-radius: 25%}
+<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>style</span><span class="token punctuation">&gt;</span></span>
+![img100x](img/Hyperlink-Wikipedia.svg.png)</code></pre>
+<style>
+img[alt=img100x] {width: 100px; border: 5px solid red; border-radius: 25%}
+</style>
+<p class="md-image-group row"><div class="col-sm-12"><a class="md-image-selfref cboxElement" href="./img/Hyperlink-Wikipedia.svg.png" title=""><img src="./img/Hyperlink-Wikipedia.svg.png" alt="img100x" class="img-responsive img-thumbnail"></a></div></p>
+<h2 id="code" class="md-inpage-anchor">Code<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Code">?</a></span></h2>
+<pre><code>`a line of code`
+
+``literal backtick (`)``</code></pre><p><div class="md-text"><code>a line of code</code></div></p>
+<p><div class="md-text"><code>literal backtick (`)</code></div></p>
+<h3 id="indented-block" class="md-inpage-anchor">Indented Block<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Indented_Block">?</a></span></h3>
+<pre><code>    a line of code
+    literal backtick (`)</code></pre><p><div class="md-text">outputs:</div></p>
+<pre><code>a line of code
+literal backtick (`)</code></pre><h3 id="highlighting" class="md-inpage-anchor">Highlighting<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Highlighting">?</a></span></h3>
+<pre><code>```javascript
+(function(){
+  "use strict";
+  var t = "a string";
+  console.log(t);
+}())
+```</code></pre><p><div class="md-text">outputs:</div></p>
+<pre class="language-javascript" tabindex="0"><code class="language-javascript"><span class="token punctuation">(</span><span class="token keyword">function</span><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token punctuation">{</span>
+  <span class="token string">"use strict"</span><span class="token punctuation">;</span>
+  <span class="token keyword">var</span> t <span class="token operator">=</span> <span class="token string">"a string"</span><span class="token punctuation">;</span>
+  console<span class="token punctuation">.</span><span class="token function">log</span><span class="token punctuation">(</span>t<span class="token punctuation">)</span><span class="token punctuation">;</span>
+<span class="token punctuation">}</span><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token punctuation">)</span></code></pre>
+<h2 id="inline-html" class="md-inpage-anchor">Inline HTML<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Inline_HTML">?</a></span></h2>
+<pre class="language-html" tabindex="0"><code class="language-html"><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>dl</span><span class="token punctuation">&gt;</span></span>
+  <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>dt</span><span class="token punctuation">&gt;</span></span>A Definition List<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>dt</span><span class="token punctuation">&gt;</span></span>
+  <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>dd</span><span class="token punctuation">&gt;</span></span>Mixing Markdown might **not** work *everywhere*. <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>br</span><span class="token punctuation">&gt;</span></span>
+      Use HTML <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>em</span><span class="token punctuation">&gt;</span></span>tags<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>em</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>strong</span><span class="token punctuation">&gt;</span></span>instead<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>strong</span><span class="token punctuation">&gt;</span></span>.<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>dd</span><span class="token punctuation">&gt;</span></span>
+<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>dl</span><span class="token punctuation">&gt;</span></span></code></pre>
+<dl>
+  <dt>A Definition List</dt>
+  <dd>Mixing Markdown might **not** work *everywhere*. <br>
+      Use HTML <em>tags</em> <strong>instead</strong>.</dd>
+</dl>
+
+<h2 id="inline-comments" class="md-inpage-anchor">Inline Comments<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Inline_Comments">?</a></span></h2>
+<pre><code>&lt;!---
+This is a comment (!NOTE the 3 &lt;!--- dashes)
+--&gt;</code></pre><!---
+This is a comment (NOTE the 3 <!--- dashes)
+-->
+
+<h1 id="extensions" class="md-inpage-anchor">Extensions<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Extensions">?</a></span></h1>
+<h2 id="styles" class="md-inpage-anchor">Styles<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Styles">?</a></span></h2>
+<h3 id="kbd" class="md-inpage-anchor">&lt;kbd&gt;<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#<kbd>">?</a></span></h3>
+<pre><code>Press &lt;kbd&gt;Ctrl&lt;/kbd&gt; + &lt;kbd&gt;R&lt;/kbd&gt; or &lt;kbd&gt;F5&lt;/kbd&gt;</code></pre><p><div class="md-text">Press <kbd>Ctrl</kbd> + <kbd>R</kbd> or <kbd>F5</kbd></div></p>
+<h2 id="abbreviation" class="md-inpage-anchor">Abbreviation<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Abbreviation">?</a></span></h2>
+<p><div class="md-text">Provided by <a href="https://www.npmjs.com/package/markdown-it-abbr">markdown-it-abbr</a>.</div></p>
+<pre><code>*[HTML]: Hyper Text Markup Language
+*[W3C]:  World Wide Web Consortium
+The HTML specification
+is maintained by the W3C.</code></pre><p><div class="md-text">*[HTML]: Hyper Text Markup Language<br>*[W3C]:  World Wide Web Consortium<br>The HTML specification<br>is maintained by the W3C.</div></p>
+<h2 id="admonitions" class="md-inpage-anchor">Admonitions<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Admonitions">?</a></span></h2>
+<p><div class="md-text">See <a href="https://npmjs.org/package/markdown-it-admon">markdown-it-admon</a> for supported admonitions.</div></p>
+<pre><code>!!! note 
+    A note with some text</code></pre><p><div class="md-text">!!! note<br>    A note with some text</div></p>
+<pre><code>!!! warning Warning with custom Title
+    *Here be dragons!*</code></pre><p><div class="md-text">!!! warning Warning with custom title<br>    <em>Here be dragons!</em></div></p>
+<pre><code>!!! info nested admonitions
+    An info box
+
+    !!! snippet
+
+        ```js
+        console.log('Hello World')
+        ```
+
+    !!! tip ""
+        This box has not title.
+
+
+Two empty lines auto-close</code></pre><p><div class="md-text">!!! info nested admonitions<br>    An info box</div></p>
+<pre><code>!!! snippet
+
+    ```js
+    console.log('Hello World')
+    ```
+
+!!! tip ""
+    This box has not title.</code></pre><p><div class="md-text">The following admonition types are supported:</div></p>
+<ul>
+<li><code>note</code>,</li>
+<li><code>summary</code>, <code>abstract</code>, <code>tldr</code>,</li>
+<li><code>info</code>, <code>todo</code>,</li>
+<li><code>tip</code>, <code>hint</code>,</li>
+<li><code>success</code>, <code>check</code>, <code>done</code>,</li>
+<li><code>question</code>, <code>help</code>, <code>faq</code>,</li>
+<li><code>warning</code>, <code>attention</code>, <code>caution</code>,</li>
+<li><code>failure</code>, <code>fail</code>, <code>missing</code>,</li>
+<li><code>danger</code>, <code>error</code>, <code>bug</code>,</li>
+<li><code>example</code>, <code>snippet</code>,</li>
+<li><code>quote</code>, <code>cite</code></li>
+</ul>
+<p><div class="md-text">however, you’re free to use whatever you want</div></p>
+<h2 id="attributes" class="md-inpage-anchor">Attributes<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Attributes">?</a></span></h2>
+<p><div class="md-text">Provided by <a href="https://npmjs.org/package/markdown-it-attrs">markdown-it-attrs</a>.</div></p>
+<pre><code>&lt;style&gt;
+.style-me { color: magenta; border: 1px solid cyan; padding: 0 0.25em; }
+.red { color: red; }
+.border { border: 2px solid grey; }
+&lt;/style&gt;
+#### header {.style-me}
+
+paragraph {data-toggle=modal .style-me} 
+
+paragraph *style me*{.red} more text
+
+```python {.border}
+nums = [x for x in range(10)]
+```</code></pre><style>
+.style-me { color: magenta; border: 1px solid cyan; padding: 0 0.25em; }
+.red { color: red; }
+.border { border: 2px solid grey; }
+</style>
+<h4 id="header-style-me" class="md-inpage-anchor">header {.style-me}<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#header_{.style-me}">?</a></span></h4>
+<p><div class="md-text">paragraph {data-toggle=modal .style-me}</div></p>
+<p><div class="md-text">paragraph <em>style me</em>{.red} more text</div></p>
+<pre class="language-python" tabindex="0"><code class="language-python">nums <span class="token operator">=</span> <span class="token punctuation">[</span>x <span class="token keyword">for</span> x <span class="token keyword">in</span> <span class="token builtin">range</span><span class="token punctuation">(</span><span class="token number">10</span><span class="token punctuation">)</span><span class="token punctuation">]</span></code></pre>
+<h2 id="definition-lists" class="md-inpage-anchor">Definition Lists<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Definition_Lists">?</a></span></h2>
+<p><div class="md-text">Provided by <a href="https://npmjs.org/package/markdown-it-deflist">markdown-it-deflist</a>.</div></p>
+<pre><code>Term 1
+
+:   Definition 1
+
+Term 2 with *inline markup*
+
+:   Definition 2
+
+        { some code, part of Definition 2 }
+
+    Third paragraph of definition 2.</code></pre><p><div class="md-text">Term 1</div></p>
+<p><div class="md-text">:   Definition 1</div></p>
+<p><div class="md-text">Term 2 with <em>inline markup</em></div></p>
+<p><div class="md-text">:   Definition 2</div></p>
+<pre><code>    { some code, part of Definition 2 }
+
+Third paragraph of definition 2.</code></pre><hr>
+<pre><code>Term 1
+  ~ Definition 1
+
+Term 2
+  ~ Definition 2a
+  ~ Definition 2b</code></pre><p><div class="md-text">Term 1<br>  ~ Definition 1</div></p>
+<p><div class="md-text">Term 2<br>  ~ Definition 2a<br>  ~ Definition 2b</div></p>
+<h2 id="emoji" class="md-inpage-anchor">Emoji<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Emoji">?</a></span></h2>
+<p><div class="md-text">Provided by <a href="https://npmjs.org/package/markdown-it-emoji">markdown-it-emoji</a>.<br>See <a href="http://www.webpagefx.com/tools/emoji-cheat-sheet/">http://www.webpagefx.com/tools/emoji-cheat-sheet/</a> for supported emojis.</div></p>
+<p><div class="md-text">:smile: <code>:smile:</code><br>:blush: <code>:blush:</code><br>:sunny: <code>:sunny:</code><br>:heavy_multiplication_x: <code>:heavy_multiplication_x:</code><br>:heavy_check_mark: <code>:heavy_check_mark:</code>  </div></p>
+<h2 id="footnotes" class="md-inpage-anchor">Footnotes<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Footnotes">?</a></span></h2>
+<p><div class="md-text">Provided by <a href="https://npmjs.org/package/markdown-it-footnote">markdown-it-footnote</a>.</div></p>
+<pre><code>Footnote 1 link[^first].
+
+Footnote 2 link[^second].
+
+Inline footnote^[Text of inline footnote] definition.
+
+Duplicated footnote reference[^second].
+
+[^first]: Footnote **can have markup**
+
+    and multiple paragraphs.
+
+[^second]: Footnote text.</code></pre><p><div class="md-text">Footnote 1 link[^first].</div></p>
+<p><div class="md-text">Footnote 2 link[^second].</div></p>
+<p><div class="md-text">Inline footnote^[Text of inline footnote] definition.</div></p>
+<p><div class="md-text">Duplicated footnote reference[^second].</div></p>
+<p><div class="md-text">[^first]: Footnote <strong>can have markup</strong></div></p>
+<pre><code>and multiple paragraphs.</code></pre><p><div class="md-text">[^second]: Footnote text.</div></p>
+<h2 id="mark" class="md-inpage-anchor">Mark<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Mark">?</a></span></h2>
+<p><div class="md-text">Provided by <a href="https://npmjs.org/package/markdown-it-mark">markdown-it-mark</a>.</div></p>
+<pre><code>A ==marked== text.</code></pre><p><div class="md-text">A ==marked== text.</div></p>
+<h2 id="math-with-katex" class="md-inpage-anchor">Math with KaTeX<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Math_with_KaTeX">?</a></span></h2>
+<p><div class="md-text">See <a href="https://katex.org/docs/supported.html">KaTeX</a> for supported functions</div></p>
+<pre><code>The Pythagorean Theorem, $a^2 + b^2 = c^2$, is useful for computing distances.
+
+Formula is one that you learned in Calculus class.
+
+$$\int_0^1 x^n dx = \frac{1}{n+1}$$
+
+When $a \ne 0$, there are two solutions to $(ax^2 + bx + c = 0)$ and they are
+
+$$x = {-b \pm \sqrt{b^2-4ac} \over 2a}$$</code></pre><p><div class="md-text">The Pythagorean Theorem, $a^2 + b^2 = c^2$, is useful for computing distances.</div></p>
+<p><div class="md-text">Formula is one that you learned in Calculus class.</div></p>
+<p><div class="md-text">$$\int_0^1 x^n dx = \frac{1}{n+1}$$</div></p>
+<p><div class="md-text">When $a \ne 0$, there are two solutions to $(ax^2 + bx + c = 0)$ and they are</div></p>
+<p><div class="md-text">$$x = {-b \pm \sqrt{b^2-4ac} \over 2a}$$</div></p>
+<h2 id="multimarkdown-table-syntax" class="md-inpage-anchor">MultiMarkdown table syntax<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#MultiMarkdown_table_syntax">?</a></span></h2>
+<p><div class="md-text">Provided by <a href="https://github.com/RedBug312/markdown-it-multimd-table">markdown-it-multimd-table</a>.</div></p>
+<p><div class="md-text"><strong>Grouping</strong></div></p>
+<pre><code>|             |          Grouping           ||
+First Header  | Second Header | Third Header |
+ ------------ | :-----------: | -----------: |
+Content       |          *Long Cell*        ||
+Content       |   **Cell**    |         Cell |
+
+New section   |     More      |         Data |
+And more      | With an escaped '\\|'       ||
+[Prototype table]</code></pre><p><div class="md-text">|             |          Grouping           ||<br>First Header  | Second Header | Third Header |<br> ------------ | :-----------: | -----------: |<br>Content       |          <em>Long Cell</em>        ||<br>Content       |   <strong>Cell</strong>    |         Cell |</div></p>
+<p><div class="md-text">New section   |     More      |         Data |<br>And more      | With an escaped '\|'       ||<br>[Prototype table]</div></p>
+<hr>
+<p><div class="md-text"><strong>Multiline</strong></div></p>
+<pre><code>|   Markdown   | Rendered HTML |
+|--------------|---------------|
+|    *Italic*  | *Italic*      | \
+|              |               |
+|    - Item 1  | - Item 1      | \
+|    - Item 2  | - Item 2      |
+|    ```python | ```python       \
+|    .1 + .2   | .1 + .2         \
+|    ```       | ```           |</code></pre><table class="table table-bordered">
+<thead>
+<tr>
+<th>Markdown</th>
+<th>Rendered HTML</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><em>Italic</em></td>
+<td><em>Italic</em></td>
+</tr>
+<tr>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td>- Item 1</td>
+<td>- Item 1</td>
+</tr>
+<tr>
+<td>- Item 2</td>
+<td>- Item 2</td>
+</tr>
+<tr>
+<td>```python</td>
+<td>```python       \</td>
+</tr>
+<tr>
+<td>.1 + .2</td>
+<td>.1 + .2         \</td>
+</tr>
+<tr>
+<td>```</td>
+<td>```</td>
+</tr>
+</tbody></table>
+<hr>
+<p><div class="md-text"><strong>Rowspan</strong></div></p>
+<pre><code>Stage              | Direct Products | ATP Yields
+-----------------: | --------------: | ---------:
+Glycolysis         | 2 ATP           ||
+^^                 | 2 NADH          | 3--5 ATP |
+Pyruvaye oxidation | 2 NADH          | 5 ATP |
+Citric acid cycle  | 2 ATP           ||
+^^                 | 6 NADH          | 15 ATP |
+^^                 | 2 FADH2         | 3 ATP |
+**30--32** ATP     |||
+[Net ATP yields per hexose]</code></pre><table class="table table-bordered">
+<thead>
+<tr>
+<th align="right">Stage</th>
+<th align="right">Direct Products</th>
+<th align="right">ATP Yields</th>
+</tr>
+</thead>
+<tbody><tr>
+<td align="right">Glycolysis</td>
+<td align="right">2 ATP</td>
+<td align="right"></td>
+</tr>
+<tr>
+<td align="right">^^</td>
+<td align="right">2 NADH</td>
+<td align="right">3--5 ATP</td>
+</tr>
+<tr>
+<td align="right">Pyruvaye oxidation</td>
+<td align="right">2 NADH</td>
+<td align="right">5 ATP</td>
+</tr>
+<tr>
+<td align="right">Citric acid cycle</td>
+<td align="right">2 ATP</td>
+<td align="right"></td>
+</tr>
+<tr>
+<td align="right">^^</td>
+<td align="right">6 NADH</td>
+<td align="right">15 ATP</td>
+</tr>
+<tr>
+<td align="right">^^</td>
+<td align="right">2 FADH2</td>
+<td align="right">3 ATP</td>
+</tr>
+<tr>
+<td align="right"><strong>30--32</strong> ATP</td>
+<td align="right"></td>
+<td align="right"></td>
+</tr>
+<tr>
+<td align="right">[Net ATP yields per hexose]</td>
+<td align="right"></td>
+<td align="right"></td>
+</tr>
+</tbody></table>
+<hr>
+<p><div class="md-text"><strong>Headerless</strong></div></p>
+<pre><code>|--|--|--|--|--|--|--|--|
+|♜ |  |♝ |♛ |♚ |♝ |♞ |♜ |
+|  |♟ |♟ |♟ |  |♟ |♟ |♟ |
+|♟ |  |♞ |  |  |  |  |  |
+|  |♗ |  |  |♟ |  |  |  |
+|  |  |  |  |♙ |  |  |  |
+|  |  |  |  |  |♘ |  |  |
+|♙ |♙ |♙ |♙ |  |♙ |♙ |♙ |
+|♖ |♘ |♗ |♕ |♔ |  |  |♖ |</code></pre><p><div class="md-text">|--|--|--|--|--|--|--|--|<br>|♜ |  |♝ |♛ |♚ |♝ |♞ |♜ |<br>|  |♟ |♟ |♟ |  |♟ |♟ |♟ |<br>|♟ |  |♞ |  |  |  |  |  |<br>|  |♗ |  |  |♟ |  |  |  |<br>|  |  |  |  |♙ |  |  |  |<br>|  |  |  |  |  |♘ |  |  |<br>|♙ |♙ |♙ |♙ |  |♙ |♙ |♙ |<br>|♖ |♘ |♗ |♕ |♔ |  |  |♖ |</div></p>
+<h2 id="subscript" class="md-inpage-anchor">Subscript<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Subscript">?</a></span></h2>
+<p><div class="md-text">Provided by <a href="https://npmjs.org/package/markdown-it-sub">markdown-it-sub</a>.</div></p>
+<pre><code>H~2~0</code></pre><p><div class="md-text">H<del>2</del>0</div></p>
+<h2 id="superscript" class="md-inpage-anchor">Superscript<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Superscript">?</a></span></h2>
+<p><div class="md-text">Provided by <a href="https://npmjs.org/package/markdown-it-sup">markdown-it-sup</a>.</div></p>
+<pre><code>29^th^</code></pre><p><div class="md-text">29^th^</div></p>
+<h2 id="tasklists" class="md-inpage-anchor">Tasklists<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Tasklists">?</a></span></h2>
+<p><div class="md-text">Provided by <a href="https://npmjs.org/package/markdown-it-task-lists">markdown-it-task-lists</a>.</div></p>
+<pre><code>- [ ] Open
+- [x] Done</code></pre><ul>
+<li><input disabled="" type="checkbox"> Open</li>
+<li><input checked="" disabled="" type="checkbox"> Done</li>
+</ul>
+<h1 id="preprocessor" class="md-inpage-anchor">Preprocessor<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Preprocessor">?</a></span></h1>
+<p><div class="md-text">Check <a href="https://github.com/commenthol/markedpp">markedpp</a> for further options.</div></p>
+<h2 id="include-other-files" class="md-inpage-anchor">Include other files<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Include_other_files">?</a></span></h2>
+<p><div class="md-text">See <a href="https://github.com/commenthol/markedpp#include">https://github.com/commenthol/markedpp#include</a></div></p>
+<p><div class="md-text"><strong>Syntax:</strong></div></p>
+<pre><code>!include(path_to/include.md)</code></pre><!-- include (path_to/include.md) -->
+
+<hr>
+<p><div class="md-text">This is an included file.</div></p>
+<p><div class="md-text">!include (path_to/include.md)</div></p>
+<hr>
+<!-- /include -->
+
+<p><a name="table-of-contents-1"></a></p>
+<h2 id="table-of-contents-1" class="md-inpage-anchor">Table of Contents<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Table_of_Contents">?</a></span></h2>
+<p><div class="md-text">See <a href="https://github.com/commenthol/markedpp#toc">https://github.com/commenthol/markedpp#toc</a> for more options</div></p>
+<p><div class="md-text"><strong>Syntax:</strong></div></p>
+<pre><code>!toc
+
+!toc(minlevel=3 maxlevel=4 omit="h3;Unordered")</code></pre><!-- !toc (minlevel=3 maxlevel=4 omit="h3;Unordered") -->
+
+<ul>
+<li><a href="./#escaping">Escaping</a></li>
+<li><a href="./#ordered-mixed">Ordered, Mixed</a></li>
+<li><a href="./#column-alignment">Column Alignment</a></li>
+<li><a href="./#link-within-document">Link within document</a></li>
+<li><a href="./#indented-block">Indented Block</a></li>
+<li><a href="./#highlighting">Highlighting</a></li>
+</ul>
+<!-- toc! -->
+
+<h2 id="reference-list" class="md-inpage-anchor">Reference list<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Reference_list">?</a></span></h2>
+<p><div class="md-text">See <a href="https://github.com/commenthol/markedpp#ref">https://github.com/commenthol/markedpp#ref</a></div></p>
+<p><div class="md-text"><strong>Syntax:</strong></div></p>
+<pre><code>!ref</code></pre><!-- !ref -->
+
+<ul>
+<li><a href="https://help.github.com/articles/github-flavored-markdown">Github Flavored Markdown</a></li>
+<li><a href="http://daringfireball.net/projects/markdown/syntax">Markdown Specification</a></li>
+<li><a href="https://github.com/commenthol/markedpp">markedpp</a></li>
+<li><a href="http://example.com">Referenced Link</a></li>
+</ul>
+<!-- ref! -->
+
+</div></div></div></div></div></div><hr style="position: relative; margin-top: 1em;"><div class="scontainer" style="position: relative; margin-top: 1em;"><div class="pull-right md-copyright-footer"> <span id="md-footer-additional">All content and images © by John Doe</span>Website generated with <a href="http://www.mdwiki.info">MDwiki</a> © Timo Dörr and contributors. </div></div></div>
+  <script src="//localhost:35729/livereload.js?snipver=1" async="" defer=""></script>
+
+<div id="cboxOverlay" style="display: none;"></div><div id="colorbox" class="" role="dialog" tabindex="-1" style="display: none;"><div id="cboxWrapper"><div><div id="cboxTopLeft" style="float: left;"></div><div id="cboxTopCenter" style="float: left;"></div><div id="cboxTopRight" style="float: left;"></div></div><div style="clear: left;"><div id="cboxMiddleLeft" style="float: left;"></div><div id="cboxContent" style="float: left;"><div id="cboxTitle" style="float: left;"></div><div id="cboxCurrent" style="float: left;"></div><button type="button" id="cboxPrevious"></button><button type="button" id="cboxNext"></button><button type="button" id="cboxSlideshow"></button><div id="cboxLoadingOverlay" style="float: left;"></div><div id="cboxLoadingGraphic" style="float: left;"></div></div><div id="cboxMiddleRight" style="float: left;"></div></div><div style="clear: left;"><div id="cboxBottomLeft" style="float: left;"></div><div id="cboxBottomCenter" style="float: left;"></div><div id="cboxBottomRight" style="float: left;"></div></div></div><div style="position: absolute; width: 9999px; visibility: hidden; display: none; max-width: none;"></div></div><span id="start-tests" style="display: none;"></span></body></html>

--- a/tests/crappy_tests/cheatsheet.marked-3.0.8.html
+++ b/tests/crappy_tests/cheatsheet.marked-3.0.8.html
@@ -1,0 +1,863 @@
+<!DOCTYPE html><html class=""><!--
+   This is MDwiki v0.6.6 in debug mode
+   (C) 2013 by Timo Dörr and contributors. This software is licensed
+   under the terms of the GPLv3 with additional terms applied.
+   See https://github.com/Dynalon/mdwiki/blob/0.6.x/LICENSE.txt for more detail.
+   See https://github.com/Dynalon/mdwiki.git for a copy of the source code.
+--><head>
+    <title>MDwiki</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="fragment" content="!">
+    <link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
+    <meta charset="UTF-8">
+<link rel="stylesheet" href="node_modules/bootstrap/dist/css/bootstrap.css" type="text/css">
+<link rel="stylesheet" href="node_modules/prismjs/themes/prism.css" type="text/css">
+<link rel="stylesheet" href="node_modules/prismjs/plugins/previewers/prism-previewers.css" type="text/css">
+<link rel="stylesheet" href="src/lib/jquery-colorbox/css/colorbox.css" type="text/css">
+<link rel="stylesheet" href="src/css/mdwiki.css" type="text/css">
+<script type="text/javascript" src="node_modules/jquery/dist/jquery.js"></script>
+<script type="text/javascript" src="node_modules/bootstrap/dist/js/bootstrap.js"></script>
+<script type="text/javascript" src="node_modules/prismjs/prism.js"></script>
+<script type="text/javascript" src="src/_compiled/js/prism-ext.js"></script>
+<script type="text/javascript" src="node_modules/jquery-colorbox/jquery.colorbox.js"></script>
+<script type="text/javascript" src="node_modules/marked/lib/marked.js"></script>
+<script type="text/javascript" src="src/_compiled/js/mdwiki.js"></script>
+<script type="text/javascript">$.md.logThreshold = $.md.loglevel.DEBUG;</script>
+  </head>
+  <body>
+    <noscript>
+        This website requires Javascript to be enabled. Please turn on Javascript
+        and reload the page.
+    </noscript>
+
+    <div id="md-all"><div id="md-menu">
+
+<div id="md-main-navbar" class="navbar navbar-default navbar-fixed-top" role="navigation"><div class="navbar-header"><button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-ex1-collapse"><span class="sr-only">Toggle navigation</span><span class="icon-bar"></span><span class="icon-bar"></span><span class="icon-bar"></span></button><a class="navbar-brand" href="#"></a></div><div class="collapse navbar-collapse navbar-ex1-collapse"><ul class="nav navbar-nav"><ul class="nav navbar-nav navbar-right"></ul><li><a href="#!index.md">Index</a></li><li class="active"><a href="#!cheatsheet.md">Cheatsheet</a></li></ul></div></div></div><div class="container" id="md-body-container"><div class="row" id="md-body-row"><div id="md-body" style="margin-top: 60px;"><div class="container" id="md-title-container"><div class="row" id="md-title-row"><div id="md-title" class="col-md-12"><div class="page-header"><h1 id="cheatsheet---markdown-syntax-with-gfm">Cheatsheet - Markdown Syntax with GFM</h1></div></div></div></div><div class="container" id="md-menu-container"><div class="row" id="md-menu-row"></div></div><div class="container" id="md-content-container"><div class="row" id="md-content-row"><div id="md-content" class="col-md-12"><hr>
+<p><div class="md-text">title: Cheatsheet - Markdown Syntax with GFM MMM<br>description: Extended markdown syntax<br>tags:</div></p>
+<ul>
+<li>markadown</li>
+<li>extended</li>
+<li>gfm<br>Tags:</li>
+</ul>
+<hr>
+
+<p><div class="md-text">This cheatsheet uses markdown syntax based on:</div></p>
+<ul>
+<li><a href="http://daringfireball.net/projects/markdown/syntax">Markdown Specification</a></li>
+<li><a href="https://help.github.com/articles/github-flavored-markdown">Github Flavored Markdown</a></li>
+<li><a href="./#extensions">Markdown-it Parser Extensions</a></li>
+</ul>
+<h2 id="table-of-contents" class="md-inpage-anchor">Table of Contents<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Table_of_Contents">?</a></span></h2>
+<ul>
+<li>Markdown<ul>
+<li><a href="./#headers">Headers</a></li>
+<li><a href="./#paragraphs-and-line-breaks">Paragraphs and Line Breaks</a></li>
+<li><a href="./#styling-text">Styling Text</a><ul>
+<li><a href="./#escaping">Escaping</a></li>
+</ul>
+</li>
+<li><a href="./#lists">Lists</a><ul>
+<li><a href="./#unordered">Unordered</a></li>
+<li><a href="./#ordered-mixed">Ordered, Mixed</a></li>
+</ul>
+</li>
+<li><a href="./#tables">Tables</a><ul>
+<li><a href="./#column-alignment">Column Alignment</a></li>
+</ul>
+</li>
+<li><a href="./#links">Links</a><ul>
+<li><a href="./#link-within-document">Link within document</a></li>
+</ul>
+</li>
+<li><a href="./#block-quotes">Block Quotes</a></li>
+<li><a href="./#horizontal-ruler">Horizontal Ruler</a></li>
+<li><a href="./#images">Images</a></li>
+<li><a href="./#code">Code</a><ul>
+<li><a href="./#indented-block">Indented Block</a></li>
+<li><a href="./#highlighting">Highlighting</a></li>
+</ul>
+</li>
+<li><a href="./#inline-html">Inline HTML</a></li>
+<li><a href="./#inline-comments">Inline Comments</a></li>
+</ul>
+</li>
+<li><a href="./#extensions">Extensions</a><ul>
+<li><a href="./#styles">Styles</a></li>
+<li><a href="./#abbreviation">Abbreviation</a></li>
+<li><a href="./#admonitions">Admonitions</a></li>
+<li><a href="./#attributes">Attributes</a></li>
+<li><a href="./#definition-lists">Definition Lists</a></li>
+<li><a href="./#emoji">Emoji</a></li>
+<li><a href="./#footnotes">Footnotes</a></li>
+<li><a href="./#math-with-katex">Math with KaTeX</a></li>
+<li><a href="./#mark">Mark</a></li>
+<li><a href="./#multimarkdown-table-syntax">MultiMarkdown table syntax</a></li>
+<li><a href="./#subscript">Subscript</a></li>
+<li><a href="./#superscript">Superscript</a></li>
+<li><a href="./#tasklists">Tasklists</a></li>
+</ul>
+</li>
+<li><a href="./#preprocessor">Preprocessor</a><ul>
+<li><a href="./#include-other-files">Include other files</a></li>
+<li><a href="./#table-of-contents-1">Table of Contents</a></li>
+<li><a href="./#reference-list">Reference list</a></li>
+</ul>
+</li>
+</ul>
+<!-- toc (level=4) -->
+
+<h2 id="headers" class="md-inpage-anchor">Headers<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Headers">?</a></span></h2>
+<pre><code># h1
+
+## h2
+
+### h3
+
+#### h4
+
+##### h5
+
+###### h6
+
+h1 Alternate
+============
+
+h2 Alternate
+------------
+</code></pre>
+<h1 id="h1" class="md-inpage-anchor">h1<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#h1">?</a></span></h1>
+<h2 id="h2" class="md-inpage-anchor">h2<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#h2">?</a></span></h2>
+<h3 id="h3" class="md-inpage-anchor">h3<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#h3">?</a></span></h3>
+<h4 id="h4" class="md-inpage-anchor">h4<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#h4">?</a></span></h4>
+<h5 id="h5" class="md-inpage-anchor">h5<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#h5">?</a></span></h5>
+<h6 id="h6" class="md-inpage-anchor">h6<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#h6">?</a></span></h6>
+<h1 id="h1-alternate" class="md-inpage-anchor">h1 Alternate<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#h1_Alternate">?</a></span></h1>
+<h2 id="h2-alternate" class="md-inpage-anchor">h2 Alternate<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#h2_Alternate">?</a></span></h2>
+<h2 id="paragraphs-and-line-breaks" class="md-inpage-anchor">Paragraphs and Line Breaks<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Paragraphs_and_Line_Breaks">?</a></span></h2>
+<pre><code>A paragraph is a paragraph is a paragraph is a paragraph is a paragraph. Is a paragraph is a paragraph is a paragraph is a paragraph is a paragraph. Is a paragraph is a paragraph is a paragraph.
+This is a not a new line.
+This as not as well..
+
+This is a new paragraph.
+
+Forcing a new line with `&lt;br&gt;` &lt;br&gt; causes a new line.
+
+Or ending a line with two spaces  
+causes a line break as well
+</code></pre>
+<p><div class="md-text">A paragraph is a paragraph is a paragraph is a paragraph is a paragraph. Is a paragraph is a paragraph is a paragraph is a paragraph is a paragraph. Is a paragraph is a paragraph is a paragraph.<br>This is a not a new line.<br>This as not as well..</div></p>
+<p><div class="md-text">This is a new paragraph.</div></p>
+<p><div class="md-text">Forcing a new line with <code>&lt;br&gt;</code> <br> causes a new line.</div></p>
+<p><div class="md-text">Or ending a line with two spaces<br>causes a line-break as well</div></p>
+<h2 id="styling-text" class="md-inpage-anchor">Styling Text<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Styling_Text">?</a></span></h2>
+<pre><code>**Bold** Text      === __Bold__ Text
+*Emphasised* Text  === _Emphasised_ Text
+`monospaced` Text
+~~strikethrough~~ Text
+Wi*thin*Words   - but not -   Wi_thin_Words
+</code></pre>
+<p><div class="md-text"><strong>Bold</strong> Text      === <strong>Bold</strong> Text</div></p>
+<p><div class="md-text"><em>Emphasised</em> Text  === <em>Emphasised</em> Text</div></p>
+<p><div class="md-text"><code>Monospaced</code> Text</div></p>
+<p><div class="md-text"><del>Strikethrough</del> Text</div></p>
+<p><div class="md-text">Wi<em>thin</em>Words   - but not -   Wi_thin_Words</div></p>
+<h3 id="escaping" class="md-inpage-anchor">Escaping<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Escaping">?</a></span></h3>
+<pre><code>\\   backslash
+\`   backtick
+\*   asterisk
+\_   underscore
+\{\}  curly braces
+\[\]  square brackets
+\(\)  parentheses
+\#   hash mark
+\+   plus sign
+\-   minus sign (hyphen)
+\.   dot
+\!   exclamation mark
+</code></pre>
+<p><div class="md-text">\   backslash<br><br>`   backtick<br><br>*   asterisk<br><br>_   underscore<br><br>{}  curly braces<br><br>[]  square brackets<br><br>()  parentheses<br><br>#   hash mark<br><br>+   plus sign<br><br>-   minus sign (hyphen)<br><br>.   dot<br><br>!   exclamation mark</div></p>
+<h2 id="lists" class="md-inpage-anchor">Lists<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Lists">?</a></span></h2>
+<h3 id="unordered" class="md-inpage-anchor">Unordered<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Unordered">?</a></span></h3>
+<pre><code>* Cyan
+* Magenta
+* Yellow
+
+- Red
+- Green
+- Blue
+
++ Black
++ Gray
++ White
+
+* Cyan
+  * No Red
+  * Green
+    * Is a color
+      * like the grass
+  * Blue
+    * Another color
+    * like the sky
+* Magenta
+* Yellow
+</code></pre>
+<ul>
+<li>Cyan</li>
+<li>Magenta</li>
+<li>Yellow</li>
+</ul>
+<ul>
+<li>Red</li>
+<li>Green</li>
+<li>Blue</li>
+</ul>
+<ul>
+<li>Black</li>
+<li>Gray</li>
+<li>White</li>
+</ul>
+<ul>
+<li>Cyan<ul>
+<li>No Red</li>
+<li>Green<ul>
+<li>Is a color<ul>
+<li>like the grass</li>
+</ul>
+</li>
+</ul>
+</li>
+<li>Blue<ul>
+<li>Another color</li>
+<li>like the sky</li>
+</ul>
+</li>
+</ul>
+</li>
+<li>Magenta</li>
+<li>Yellow</li>
+</ul>
+<h3 id="ordered-mixed" class="md-inpage-anchor">Ordered, Mixed<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Ordered,_Mixed">?</a></span></h3>
+<pre><code>1. Red
+2. Green
+3. Blue
+
+2. Black
+3. Grey
+1. White
+
+&lt;!--- --&gt;
+
+40. Cyan
+   1. RGB (0, 255, 255)
+   1. A color between green and blue
+      * Green
+      * Blue
+2. Magenta
+10. Yellow
+</code></pre>
+<p class="alert alert-info"><div class="md-text"><span style="color: #f55;"><strong>Note</strong>: Wrong numbers get corrected into right order!</span></div></p>
+<ol>
+<li><p><div class="md-text">Red</div></p>
+</li>
+<li><p><div class="md-text">Green</div></p>
+</li>
+<li><p class="alert alert-info"><div class="md-text">Blue <span style="color: #f55;"><strong>Note:</strong> Counting continues with line-breaks</span></div></p>
+</li>
+<li><p><div class="md-text">Black</div></p>
+</li>
+<li><p><div class="md-text">Grey</div></p>
+</li>
+<li><p><div class="md-text">White</div></p>
+</li>
+</ol>
+<!--- -->
+
+<ol start="40">
+<li>Cyan <span style="color: #f55;"><strong>Note:</strong> Counting is restarted with 40 after &lt;!--- --&gt;</span></li>
+<li>RGB (0, 255, 255)</li>
+<li>A color between green and blue<ul>
+<li>Green</li>
+<li>Blue</li>
+</ul>
+</li>
+<li>Magenta</li>
+<li>Yellow</li>
+</ol>
+<h2 id="tables" class="md-inpage-anchor">Tables<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Tables">?</a></span></h2>
+<pre><code>| Column 1 | Column 2 | Column 3 |
+| ---      | ---      | ---      |
+| Row 1    | 1        | 2        |
+| Row 2    | 3        | 4        |
+</code></pre>
+<table class="table table-bordered">
+<thead>
+<tr>
+<th>Column 1</th>
+<th>Column 2</th>
+<th>Column 3</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Row 1</td>
+<td>1</td>
+<td>2</td>
+</tr>
+<tr>
+<td>Row 2</td>
+<td>3</td>
+<td>4</td>
+</tr>
+</tbody></table>
+<h3 id="column-alignment" class="md-inpage-anchor">Column Alignment<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Column_Alignment">?</a></span></h3>
+<pre><code>| Left Aligned | Center Aligned | Right Aligned |
+| ---          | :---:          | ---:          |
+| Row 1        | 1              | 2             |
+| Row 2        | 3              | 4             |
+</code></pre>
+<table class="table table-bordered">
+<thead>
+<tr>
+<th>Left Aligned</th>
+<th align="center">Center Aligned</th>
+<th align="right">Right Aligned</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Row 1</td>
+<td align="center">1</td>
+<td align="right">2</td>
+</tr>
+<tr>
+<td>Row 2</td>
+<td align="center">3</td>
+<td align="right">4</td>
+</tr>
+</tbody></table>
+<h2 id="links" class="md-inpage-anchor">Links<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Links">?</a></span></h2>
+<pre><code>http://example.com
+
+&lt;http://example.com&gt;
+
+[Linktext](http://example.com)
+
+[Reference][Referenced Link]
+
+[Referenced Link][]
+
+[Referenced Link]: http://example.com
+</code></pre>
+<p><div class="md-text"><a href="http://example.com">http://example.com</a></div></p>
+<p><div class="md-text"><a href="http://example.com">http://example.com</a></div></p>
+<p><div class="md-text"><a href="http://example.com">Linktext</a></div></p>
+<p><div class="md-text"><a href="http://example.com">Reference</a></div></p>
+<p><div class="md-text"><a href="http://example.com">Referenced Link</a></div></p>
+<h3 id="link-within-document" class="md-inpage-anchor">Link within document<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Link_within_document">?</a></span></h3>
+<pre><code>&lt;a name="cross-reference"&gt;
+
+[Cross-Reference](#cross-reference)
+</code></pre>
+<a name="cross-reference">
+
+</a><p><div class="md-text"><a name="cross-reference"></a><a href="./#cross-reference">Cross-Reference</a></div></p>
+<h2 id="block-quotes" class="md-inpage-anchor">Block Quotes<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Block_Quotes">?</a></span></h2>
+<pre><code>&gt; Block Quoted Text
+Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus. Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.
+
+&gt; Or line
+&gt; by line
+
+You need "text" to break block quotes
+
+&gt; Or with a
+&gt; &gt; nested quote
+
+&gt; line
+</code></pre>
+<blockquote>
+<p><div class="md-text">Block Quoted Text<br>Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus. Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.</div></p>
+</blockquote>
+<blockquote>
+<p><div class="md-text">Or line<br>by line</div></p>
+</blockquote>
+<p><div class="md-text">You need "text" to break block quotes</div></p>
+<blockquote>
+<p><div class="md-text">Or with a</div></p>
+<blockquote>
+<p><div class="md-text">nested quote</div></p>
+</blockquote>
+</blockquote>
+<blockquote>
+<p><div class="md-text">line</div></p>
+</blockquote>
+<h2 id="horizontal-ruler" class="md-inpage-anchor">Horizontal Ruler<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Horizontal_Ruler">?</a></span></h2>
+<p><div class="md-text">Three or more Hyphens, Asterisks, Underscores</div></p>
+<pre><code>---
+
+***
+___
+</code></pre>
+<hr>
+<hr>
+<hr>
+<h2 id="images" class="md-inpage-anchor">Images<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Images">?</a></span></h2>
+<style>
+img[alt=img100x] {width: 100px; border: 5px solid red; border-radius: 25%}
+</style>
+
+<pre><code>![Alt Text](img/Hyperlink-Wikipedia.svg.png)
+![Alt Text](img/Hyperlink-Wikipedia.svg.png "Optional Title")
+![Alt Text](http://placehold.it/150x100)
+![broken image](http://localhost/my-broken-image)
+</code></pre>
+<p class="md-image-group row"><div class="col-sm-3"><a class="md-image-selfref cboxElement" href="./img/Hyperlink-Wikipedia.svg.png" title=""><img src="./img/Hyperlink-Wikipedia.svg.png" alt="Alt Text" class="img-responsive img-thumbnail"></a></div><div class="col-sm-3"><a class="md-image-selfref cboxElement" href="./img/Hyperlink-Wikipedia.svg.png" title="Optional Title"><img src="./img/Hyperlink-Wikipedia.svg.png" alt="Alt Text" title="Optional Title" class="img-responsive img-thumbnail"></a></div><div class="col-sm-3"><a class="md-image-selfref cboxElement" href="http://placehold.it/150x100" title=""><img src="http://placehold.it/150x100" alt="Alt Text" class="img-responsive img-thumbnail"></a></div><div class="col-sm-3"><a class="md-image-selfref cboxElement" href="http://localhost/my-broken-image" title=""><img src="http://localhost/my-broken-image" alt="broken image" class="img-responsive img-thumbnail"></a></div></p>
+<p><div class="md-text">Using plain html can be used to size images:</div></p>
+<pre class="language-html" tabindex="0"><code class="language-html"><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>img</span> <span class="token attr-name">src</span><span class="token attr-value"><span class="token punctuation attr-equals">=</span><span class="token punctuation">"</span>img/Hyperlink-Wikipedia.svg.png<span class="token punctuation">"</span></span> <span class="token attr-name">title</span><span class="token attr-value"><span class="token punctuation attr-equals">=</span><span class="token punctuation">"</span>Optional Title<span class="token punctuation">"</span></span> <span class="token attr-name">alt</span><span class="token attr-value"><span class="token punctuation attr-equals">=</span><span class="token punctuation">"</span>Alt Text<span class="token punctuation">"</span></span> <span class="token attr-name">style</span><span class="token attr-value"><span class="token punctuation attr-equals">=</span><span class="token punctuation">"</span>width: 50px;<span class="token punctuation">"</span></span><span class="token punctuation">&gt;</span></span>
+</code></pre>
+<a class="md-image-selfref" href="./img/Hyperlink-Wikipedia.svg.png" title="Optional Title"><img src="./img/Hyperlink-Wikipedia.svg.png" title="Optional Title" alt="Alt Text" style="width: 50px;"></a>
+
+<p><div class="md-text">Styling images can also be done by hijacking on the <code>alt</code> attribute.</div></p>
+<pre class="language-html" tabindex="0"><code class="language-html"><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>style</span><span class="token punctuation">&gt;</span></span>
+img[alt=img100x] {width: 100px; border: 5px solid red; border-radius: 25%}
+<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>style</span><span class="token punctuation">&gt;</span></span>
+![img100x](img/Hyperlink-Wikipedia.svg.png)
+</code></pre>
+<style>
+img[alt=img100x] {width: 100px; border: 5px solid red; border-radius: 25%}
+</style>
+<p class="md-image-group row"><div class="col-sm-12"><a class="md-image-selfref cboxElement" href="./img/Hyperlink-Wikipedia.svg.png" title=""><img src="./img/Hyperlink-Wikipedia.svg.png" alt="img100x" class="img-responsive img-thumbnail"></a></div></p>
+<h2 id="code" class="md-inpage-anchor">Code<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Code">?</a></span></h2>
+<pre><code>`a line of code`
+
+``literal backtick (`)``
+</code></pre>
+<p><div class="md-text"><code>a line of code</code></div></p>
+<p><div class="md-text"><code>literal backtick (`)</code></div></p>
+<h3 id="indented-block" class="md-inpage-anchor">Indented Block<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Indented_Block">?</a></span></h3>
+<pre><code>    a line of code
+    literal backtick (`)
+</code></pre>
+<p><div class="md-text">outputs:</div></p>
+<pre><code>a line of code
+literal backtick (`)
+</code></pre>
+<h3 id="highlighting" class="md-inpage-anchor">Highlighting<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Highlighting">?</a></span></h3>
+<pre><code>```javascript
+(function(){
+  "use strict";
+  var t = "a string";
+  console.log(t);
+}())
+```
+</code></pre>
+<p><div class="md-text">outputs:</div></p>
+<pre class="language-javascript" tabindex="0"><code class="language-javascript"><span class="token punctuation">(</span><span class="token keyword">function</span><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token punctuation">{</span>
+  <span class="token string">"use strict"</span><span class="token punctuation">;</span>
+  <span class="token keyword">var</span> t <span class="token operator">=</span> <span class="token string">"a string"</span><span class="token punctuation">;</span>
+  console<span class="token punctuation">.</span><span class="token function">log</span><span class="token punctuation">(</span>t<span class="token punctuation">)</span><span class="token punctuation">;</span>
+<span class="token punctuation">}</span><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token punctuation">)</span>
+</code></pre>
+<h2 id="inline-html" class="md-inpage-anchor">Inline HTML<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Inline_HTML">?</a></span></h2>
+<pre class="language-html" tabindex="0"><code class="language-html"><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>dl</span><span class="token punctuation">&gt;</span></span>
+  <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>dt</span><span class="token punctuation">&gt;</span></span>A Definition List<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>dt</span><span class="token punctuation">&gt;</span></span>
+  <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>dd</span><span class="token punctuation">&gt;</span></span>Mixing Markdown might **not** work *everywhere*. <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>br</span><span class="token punctuation">&gt;</span></span>
+      Use HTML <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>em</span><span class="token punctuation">&gt;</span></span>tags<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>em</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>strong</span><span class="token punctuation">&gt;</span></span>instead<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>strong</span><span class="token punctuation">&gt;</span></span>.<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>dd</span><span class="token punctuation">&gt;</span></span>
+<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>dl</span><span class="token punctuation">&gt;</span></span>
+</code></pre>
+<dl>
+  <dt>A Definition List</dt>
+  <dd>Mixing Markdown might **not** work *everywhere*. <br>
+      Use HTML <em>tags</em> <strong>instead</strong>.</dd>
+</dl>
+
+<h2 id="inline-comments" class="md-inpage-anchor">Inline Comments<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Inline_Comments">?</a></span></h2>
+<pre><code>&lt;!---
+This is a comment (!NOTE the 3 &lt;!--- dashes)
+--&gt;
+</code></pre>
+<!---
+This is a comment (NOTE the 3 <!--- dashes)
+-->
+
+<h1 id="extensions" class="md-inpage-anchor">Extensions<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Extensions">?</a></span></h1>
+<h2 id="styles" class="md-inpage-anchor">Styles<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Styles">?</a></span></h2>
+<h3 id="kbd" class="md-inpage-anchor">&lt;kbd&gt;<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#<kbd>">?</a></span></h3>
+<pre><code>Press &lt;kbd&gt;Ctrl&lt;/kbd&gt; + &lt;kbd&gt;R&lt;/kbd&gt; or &lt;kbd&gt;F5&lt;/kbd&gt;
+</code></pre>
+<p><div class="md-text">Press <kbd>Ctrl</kbd> + <kbd>R</kbd> or <kbd>F5</kbd></div></p>
+<h2 id="abbreviation" class="md-inpage-anchor">Abbreviation<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Abbreviation">?</a></span></h2>
+<p><div class="md-text">Provided by <a href="https://www.npmjs.com/package/markdown-it-abbr">markdown-it-abbr</a>.</div></p>
+<pre><code>*[HTML]: Hyper Text Markup Language
+*[W3C]:  World Wide Web Consortium
+The HTML specification
+is maintained by the W3C.
+</code></pre>
+<p><div class="md-text">*[HTML]: Hyper Text Markup Language<br>*[W3C]:  World Wide Web Consortium<br>The HTML specification<br>is maintained by the W3C.</div></p>
+<h2 id="admonitions" class="md-inpage-anchor">Admonitions<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Admonitions">?</a></span></h2>
+<p><div class="md-text">See <a href="https://npmjs.org/package/markdown-it-admon">markdown-it-admon</a> for supported admonitions.</div></p>
+<pre><code>!!! note 
+    A note with some text
+</code></pre>
+<p><div class="md-text">!!! note<br>    A note with some text</div></p>
+<pre><code>!!! warning Warning with custom Title
+    *Here be dragons!*
+</code></pre>
+<p><div class="md-text">!!! warning Warning with custom title<br>    <em>Here be dragons!</em></div></p>
+<pre><code>!!! info nested admonitions
+    An info box
+
+    !!! snippet
+
+        ```js
+        console.log('Hello World')
+        ```
+
+    !!! tip ""
+        This box has not title.
+
+
+Two empty lines auto-close
+</code></pre>
+<p><div class="md-text">!!! info nested admonitions<br>    An info box</div></p>
+<pre><code>!!! snippet
+
+    ```js
+    console.log('Hello World')
+    ```
+
+!!! tip ""
+    This box has not title.
+</code></pre>
+<p><div class="md-text">The following admonition types are supported:</div></p>
+<ul>
+<li><code>note</code>,</li>
+<li><code>summary</code>, <code>abstract</code>, <code>tldr</code>,</li>
+<li><code>info</code>, <code>todo</code>,</li>
+<li><code>tip</code>, <code>hint</code>,</li>
+<li><code>success</code>, <code>check</code>, <code>done</code>,</li>
+<li><code>question</code>, <code>help</code>, <code>faq</code>,</li>
+<li><code>warning</code>, <code>attention</code>, <code>caution</code>,</li>
+<li><code>failure</code>, <code>fail</code>, <code>missing</code>,</li>
+<li><code>danger</code>, <code>error</code>, <code>bug</code>,</li>
+<li><code>example</code>, <code>snippet</code>,</li>
+<li><code>quote</code>, <code>cite</code></li>
+</ul>
+<p><div class="md-text">however, you’re free to use whatever you want</div></p>
+<h2 id="attributes" class="md-inpage-anchor">Attributes<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Attributes">?</a></span></h2>
+<p><div class="md-text">Provided by <a href="https://npmjs.org/package/markdown-it-attrs">markdown-it-attrs</a>.</div></p>
+<pre><code>&lt;style&gt;
+.style-me { color: magenta; border: 1px solid cyan; padding: 0 0.25em; }
+.red { color: red; }
+.border { border: 2px solid grey; }
+&lt;/style&gt;
+#### header {.style-me}
+
+paragraph {data-toggle=modal .style-me} 
+
+paragraph *style me*{.red} more text
+
+```python {.border}
+nums = [x for x in range(10)]
+```
+</code></pre>
+<style>
+.style-me { color: magenta; border: 1px solid cyan; padding: 0 0.25em; }
+.red { color: red; }
+.border { border: 2px solid grey; }
+</style>
+<h4 id="header-style-me" class="md-inpage-anchor">header {.style-me}<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#header_{.style-me}">?</a></span></h4>
+<p><div class="md-text">paragraph {data-toggle=modal .style-me}</div></p>
+<p><div class="md-text">paragraph <em>style me</em>{.red} more text</div></p>
+<pre class="language-python" tabindex="0"><code class="language-python">nums <span class="token operator">=</span> <span class="token punctuation">[</span>x <span class="token keyword">for</span> x <span class="token keyword">in</span> <span class="token builtin">range</span><span class="token punctuation">(</span><span class="token number">10</span><span class="token punctuation">)</span><span class="token punctuation">]</span>
+</code></pre>
+<h2 id="definition-lists" class="md-inpage-anchor">Definition Lists<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Definition_Lists">?</a></span></h2>
+<p><div class="md-text">Provided by <a href="https://npmjs.org/package/markdown-it-deflist">markdown-it-deflist</a>.</div></p>
+<pre><code>Term 1
+
+:   Definition 1
+
+Term 2 with *inline markup*
+
+:   Definition 2
+
+        { some code, part of Definition 2 }
+
+    Third paragraph of definition 2.
+</code></pre>
+<p><div class="md-text">Term 1</div></p>
+<p><div class="md-text">:   Definition 1</div></p>
+<p><div class="md-text">Term 2 with <em>inline markup</em></div></p>
+<p><div class="md-text">:   Definition 2</div></p>
+<pre><code>    { some code, part of Definition 2 }
+
+Third paragraph of definition 2.
+</code></pre>
+<hr>
+<pre><code>Term 1
+  ~ Definition 1
+
+Term 2
+  ~ Definition 2a
+  ~ Definition 2b
+</code></pre>
+<p><div class="md-text">Term 1<br>  ~ Definition 1</div></p>
+<p><div class="md-text">Term 2<br>  ~ Definition 2a<br>  ~ Definition 2b</div></p>
+<h2 id="emoji" class="md-inpage-anchor">Emoji<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Emoji">?</a></span></h2>
+<p><div class="md-text">Provided by <a href="https://npmjs.org/package/markdown-it-emoji">markdown-it-emoji</a>.<br>See <a href="http://www.webpagefx.com/tools/emoji-cheat-sheet/">http://www.webpagefx.com/tools/emoji-cheat-sheet/</a> for supported emojis.</div></p>
+<p><div class="md-text">:smile: <code>:smile:</code><br>:blush: <code>:blush:</code><br>:sunny: <code>:sunny:</code><br>:heavy_multiplication_x: <code>:heavy_multiplication_x:</code><br>:heavy_check_mark: <code>:heavy_check_mark:</code>  </div></p>
+<h2 id="footnotes" class="md-inpage-anchor">Footnotes<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Footnotes">?</a></span></h2>
+<p><div class="md-text">Provided by <a href="https://npmjs.org/package/markdown-it-footnote">markdown-it-footnote</a>.</div></p>
+<pre><code>Footnote 1 link[^first].
+
+Footnote 2 link[^second].
+
+Inline footnote^[Text of inline footnote] definition.
+
+Duplicated footnote reference[^second].
+
+[^first]: Footnote **can have markup**
+
+    and multiple paragraphs.
+
+[^second]: Footnote text.
+</code></pre>
+<p><div class="md-text">Footnote 1 link[^first].</div></p>
+<p><div class="md-text">Footnote 2 link[^second].</div></p>
+<p><div class="md-text">Inline footnote^[Text of inline footnote] definition.</div></p>
+<p><div class="md-text">Duplicated footnote reference[^second].</div></p>
+<p><div class="md-text">[^first]: Footnote <strong>can have markup</strong></div></p>
+<pre><code>and multiple paragraphs.
+</code></pre>
+<p><div class="md-text">[^second]: Footnote text.</div></p>
+<h2 id="mark" class="md-inpage-anchor">Mark<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Mark">?</a></span></h2>
+<p><div class="md-text">Provided by <a href="https://npmjs.org/package/markdown-it-mark">markdown-it-mark</a>.</div></p>
+<pre><code>A ==marked== text.
+</code></pre>
+<p><div class="md-text">A ==marked== text.</div></p>
+<h2 id="math-with-katex" class="md-inpage-anchor">Math with KaTeX<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Math_with_KaTeX">?</a></span></h2>
+<p><div class="md-text">See <a href="https://katex.org/docs/supported.html">KaTeX</a> for supported functions</div></p>
+<pre><code>The Pythagorean Theorem, $a^2 + b^2 = c^2$, is useful for computing distances.
+
+Formula is one that you learned in Calculus class.
+
+$$\int_0^1 x^n dx = \frac{1}{n+1}$$
+
+When $a \ne 0$, there are two solutions to $(ax^2 + bx + c = 0)$ and they are
+
+$$x = {-b \pm \sqrt{b^2-4ac} \over 2a}$$
+</code></pre>
+<p><div class="md-text">The Pythagorean Theorem, $a^2 + b^2 = c^2$, is useful for computing distances.</div></p>
+<p><div class="md-text">Formula is one that you learned in Calculus class.</div></p>
+<p><div class="md-text">$$\int_0^1 x^n dx = \frac{1}{n+1}$$</div></p>
+<p><div class="md-text">When $a \ne 0$, there are two solutions to $(ax^2 + bx + c = 0)$ and they are</div></p>
+<p><div class="md-text">$$x = {-b \pm \sqrt{b^2-4ac} \over 2a}$$</div></p>
+<h2 id="multimarkdown-table-syntax" class="md-inpage-anchor">MultiMarkdown table syntax<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#MultiMarkdown_table_syntax">?</a></span></h2>
+<p><div class="md-text">Provided by <a href="https://github.com/RedBug312/markdown-it-multimd-table">markdown-it-multimd-table</a>.</div></p>
+<p><div class="md-text"><strong>Grouping</strong></div></p>
+<pre><code>|             |          Grouping           ||
+First Header  | Second Header | Third Header |
+ ------------ | :-----------: | -----------: |
+Content       |          *Long Cell*        ||
+Content       |   **Cell**    |         Cell |
+
+New section   |     More      |         Data |
+And more      | With an escaped '\\|'       ||
+[Prototype table]
+</code></pre>
+<p><div class="md-text">|             |          Grouping           ||<br>First Header  | Second Header | Third Header |<br> ------------ | :-----------: | -----------: |<br>Content       |          <em>Long Cell</em>        ||<br>Content       |   <strong>Cell</strong>    |         Cell |</div></p>
+<p><div class="md-text">New section   |     More      |         Data |<br>And more      | With an escaped '\|'       ||<br>[Prototype table]</div></p>
+<hr>
+<p><div class="md-text"><strong>Multiline</strong></div></p>
+<pre><code>|   Markdown   | Rendered HTML |
+|--------------|---------------|
+|    *Italic*  | *Italic*      | \
+|              |               |
+|    - Item 1  | - Item 1      | \
+|    - Item 2  | - Item 2      |
+|    ```python | ```python       \
+|    .1 + .2   | .1 + .2         \
+|    ```       | ```           |
+</code></pre>
+<table class="table table-bordered">
+<thead>
+<tr>
+<th>Markdown</th>
+<th>Rendered HTML</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><em>Italic</em></td>
+<td><em>Italic</em></td>
+</tr>
+<tr>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td>- Item 1</td>
+<td>- Item 1</td>
+</tr>
+<tr>
+<td>- Item 2</td>
+<td>- Item 2</td>
+</tr>
+<tr>
+<td>```python</td>
+<td>```python       \</td>
+</tr>
+<tr>
+<td>.1 + .2</td>
+<td>.1 + .2         \</td>
+</tr>
+<tr>
+<td>```</td>
+<td>```</td>
+</tr>
+</tbody></table>
+<hr>
+<p><div class="md-text"><strong>Rowspan</strong></div></p>
+<pre><code>Stage              | Direct Products | ATP Yields
+-----------------: | --------------: | ---------:
+Glycolysis         | 2 ATP           ||
+^^                 | 2 NADH          | 3--5 ATP |
+Pyruvaye oxidation | 2 NADH          | 5 ATP |
+Citric acid cycle  | 2 ATP           ||
+^^                 | 6 NADH          | 15 ATP |
+^^                 | 2 FADH2         | 3 ATP |
+**30--32** ATP     |||
+[Net ATP yields per hexose]
+</code></pre>
+<table class="table table-bordered">
+<thead>
+<tr>
+<th align="right">Stage</th>
+<th align="right">Direct Products</th>
+<th align="right">ATP Yields</th>
+</tr>
+</thead>
+<tbody><tr>
+<td align="right">Glycolysis</td>
+<td align="right">2 ATP</td>
+<td align="right"></td>
+</tr>
+<tr>
+<td align="right">^^</td>
+<td align="right">2 NADH</td>
+<td align="right">3--5 ATP</td>
+</tr>
+<tr>
+<td align="right">Pyruvaye oxidation</td>
+<td align="right">2 NADH</td>
+<td align="right">5 ATP</td>
+</tr>
+<tr>
+<td align="right">Citric acid cycle</td>
+<td align="right">2 ATP</td>
+<td align="right"></td>
+</tr>
+<tr>
+<td align="right">^^</td>
+<td align="right">6 NADH</td>
+<td align="right">15 ATP</td>
+</tr>
+<tr>
+<td align="right">^^</td>
+<td align="right">2 FADH2</td>
+<td align="right">3 ATP</td>
+</tr>
+<tr>
+<td align="right"><strong>30--32</strong> ATP</td>
+<td align="right"></td>
+<td align="right"></td>
+</tr>
+<tr>
+<td align="right">[Net ATP yields per hexose]</td>
+<td align="right"></td>
+<td align="right"></td>
+</tr>
+</tbody></table>
+<hr>
+<p><div class="md-text"><strong>Headerless</strong></div></p>
+<pre><code>|--|--|--|--|--|--|--|--|
+|♜ |  |♝ |♛ |♚ |♝ |♞ |♜ |
+|  |♟ |♟ |♟ |  |♟ |♟ |♟ |
+|♟ |  |♞ |  |  |  |  |  |
+|  |♗ |  |  |♟ |  |  |  |
+|  |  |  |  |♙ |  |  |  |
+|  |  |  |  |  |♘ |  |  |
+|♙ |♙ |♙ |♙ |  |♙ |♙ |♙ |
+|♖ |♘ |♗ |♕ |♔ |  |  |♖ |
+</code></pre>
+<p><div class="md-text">|--|--|--|--|--|--|--|--|<br>|♜ |  |♝ |♛ |♚ |♝ |♞ |♜ |<br>|  |♟ |♟ |♟ |  |♟ |♟ |♟ |<br>|♟ |  |♞ |  |  |  |  |  |<br>|  |♗ |  |  |♟ |  |  |  |<br>|  |  |  |  |♙ |  |  |  |<br>|  |  |  |  |  |♘ |  |  |<br>|♙ |♙ |♙ |♙ |  |♙ |♙ |♙ |<br>|♖ |♘ |♗ |♕ |♔ |  |  |♖ |</div></p>
+<h2 id="subscript" class="md-inpage-anchor">Subscript<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Subscript">?</a></span></h2>
+<p><div class="md-text">Provided by <a href="https://npmjs.org/package/markdown-it-sub">markdown-it-sub</a>.</div></p>
+<pre><code>H~2~0
+</code></pre>
+<p><div class="md-text">H<del>2</del>0</div></p>
+<h2 id="superscript" class="md-inpage-anchor">Superscript<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Superscript">?</a></span></h2>
+<p><div class="md-text">Provided by <a href="https://npmjs.org/package/markdown-it-sup">markdown-it-sup</a>.</div></p>
+<pre><code>29^th^
+</code></pre>
+<p><div class="md-text">29^th^</div></p>
+<h2 id="tasklists" class="md-inpage-anchor">Tasklists<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Tasklists">?</a></span></h2>
+<p><div class="md-text">Provided by <a href="https://npmjs.org/package/markdown-it-task-lists">markdown-it-task-lists</a>.</div></p>
+<pre><code>- [ ] Open
+- [x] Done
+</code></pre>
+<ul>
+<li><input disabled="" type="checkbox"> Open</li>
+<li><input checked="" disabled="" type="checkbox"> Done</li>
+</ul>
+<h1 id="preprocessor" class="md-inpage-anchor">Preprocessor<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Preprocessor">?</a></span></h1>
+<p><div class="md-text">Check <a href="https://github.com/commenthol/markedpp">markedpp</a> for further options.</div></p>
+<h2 id="include-other-files" class="md-inpage-anchor">Include other files<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Include_other_files">?</a></span></h2>
+<p><div class="md-text">See <a href="https://github.com/commenthol/markedpp#include">https://github.com/commenthol/markedpp#include</a></div></p>
+<p><div class="md-text"><strong>Syntax:</strong></div></p>
+<pre><code>!include(path_to/include.md)
+</code></pre>
+<!-- include (path_to/include.md) -->
+
+<hr>
+<p><div class="md-text">This is an included file.</div></p>
+<p><div class="md-text">!include (path_to/include.md)</div></p>
+<hr>
+<!-- /include -->
+
+<p><a name="table-of-contents-1"></a></p>
+<h2 id="table-of-contents-1" class="md-inpage-anchor">Table of Contents<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Table_of_Contents">?</a></span></h2>
+<p><div class="md-text">See <a href="https://github.com/commenthol/markedpp#toc">https://github.com/commenthol/markedpp#toc</a> for more options</div></p>
+<p><div class="md-text"><strong>Syntax:</strong></div></p>
+<pre><code>!toc
+
+!toc(minlevel=3 maxlevel=4 omit="h3;Unordered")
+</code></pre>
+<!-- !toc (minlevel=3 maxlevel=4 omit="h3;Unordered") -->
+
+<ul>
+<li><a href="./#escaping">Escaping</a></li>
+<li><a href="./#ordered-mixed">Ordered, Mixed</a></li>
+<li><a href="./#column-alignment">Column Alignment</a></li>
+<li><a href="./#link-within-document">Link within document</a></li>
+<li><a href="./#indented-block">Indented Block</a></li>
+<li><a href="./#highlighting">Highlighting</a></li>
+</ul>
+<!-- toc! -->
+
+<h2 id="reference-list" class="md-inpage-anchor">Reference list<span class="anchor-highlight" style="display: none;"><a href="#!./cheatsheet.md#Reference_list">?</a></span></h2>
+<p><div class="md-text">See <a href="https://github.com/commenthol/markedpp#ref">https://github.com/commenthol/markedpp#ref</a></div></p>
+<p><div class="md-text"><strong>Syntax:</strong></div></p>
+<pre><code>!ref
+</code></pre>
+<!-- !ref -->
+
+<ul>
+<li><a href="https://help.github.com/articles/github-flavored-markdown">Github Flavored Markdown</a></li>
+<li><a href="http://daringfireball.net/projects/markdown/syntax">Markdown Specification</a></li>
+<li><a href="https://github.com/commenthol/markedpp">markedpp</a></li>
+<li><a href="http://example.com">Referenced Link</a></li>
+</ul>
+<!-- ref! -->
+
+</div></div></div></div></div></div><hr style="position: relative; margin-top: 1em;"><div class="scontainer" style="position: relative; margin-top: 1em;"><div class="pull-right md-copyright-footer"> <span id="md-footer-additional">All content and images © by John Doe</span>Website generated with <a href="http://www.mdwiki.info">MDwiki</a> © Timo Dörr and contributors. </div></div></div>
+  <script src="//localhost:35729/livereload.js?snipver=1" async="" defer=""></script>
+
+<div id="cboxOverlay" style="display: none;"></div><div id="colorbox" class="" role="dialog" tabindex="-1" style="display: none;"><div id="cboxWrapper"><div><div id="cboxTopLeft" style="float: left;"></div><div id="cboxTopCenter" style="float: left;"></div><div id="cboxTopRight" style="float: left;"></div></div><div style="clear: left;"><div id="cboxMiddleLeft" style="float: left;"></div><div id="cboxContent" style="float: left;"><div id="cboxTitle" style="float: left;"></div><div id="cboxCurrent" style="float: left;"></div><button type="button" id="cboxPrevious"></button><button type="button" id="cboxNext"></button><button type="button" id="cboxSlideshow"></button><div id="cboxLoadingOverlay" style="float: left;"></div><div id="cboxLoadingGraphic" style="float: left;"></div></div><div id="cboxMiddleRight" style="float: left;"></div></div><div style="clear: left;"><div id="cboxBottomLeft" style="float: left;"></div><div id="cboxBottomCenter" style="float: left;"></div><div id="cboxBottomRight" style="float: left;"></div></div></div><div style="position: absolute; width: 9999px; visibility: hidden; display: none; max-width: none;"></div></div><span id="start-tests" style="display: none;"></span></body></html>

--- a/tests/crappy_tests/fetch-pages.js
+++ b/tests/crappy_tests/fetch-pages.js
@@ -1,0 +1,44 @@
+// https://gist.github.com/schollz/4dcd045a95196f567ba0abdd0ac70452
+const puppeteer = require('puppeteer');
+const fs = require('fs');
+
+async function getPageContent(md_file) {
+  url = "http://localhost:3000/mdwiki-debug.html#!" + md_file
+  console.log(">>> Fetching " + url)
+
+  const browser = await puppeteer.launch({headless: "new"});
+  const page = await browser.newPage();
+  await page.setRequestInterception(true);
+
+  page.on('request', (request) => {
+    // console.log(`Intercepting: ${request.method} ${request.url}`);
+    request.continue();
+  });
+  await page.goto(url, {waitUntil: 'load'});
+  
+  // const title = await page.title();
+  // console.log(title);
+  // await page.screenshot({path:'example.png'});
+  const html = await page.content();
+  browser.close();
+
+  return html;
+}
+
+(async () => {
+  // TODO: get from mdwiki/src/assets/*.md
+  const pages = ["index", "cheatsheet"];
+
+  for (const page of pages) {
+    const content = await getPageContent(page + ".md")
+    outfile = "./" + page + ".html"
+
+    try {
+      console.log(">>> Writing " + outfile)
+      fs.writeFileSync(outfile, content);
+      // file written successfully
+    } catch (err) {
+      console.error(err);
+    }  
+  }
+})();

--- a/tests/crappy_tests/index.baseline-main.html
+++ b/tests/crappy_tests/index.baseline-main.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html><html class=""><!--
+   This is MDwiki v0.6.6 in debug mode
+   (C) 2013 by Timo Dörr and contributors. This software is licensed
+   under the terms of the GPLv3 with additional terms applied.
+   See https://github.com/Dynalon/mdwiki/blob/0.6.x/LICENSE.txt for more detail.
+   See https://github.com/Dynalon/mdwiki.git for a copy of the source code.
+--><head>
+    <title>MDwiki</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="fragment" content="!">
+    <link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
+    <meta charset="UTF-8">
+<link rel="stylesheet" href="node_modules/bootstrap/dist/css/bootstrap.css" type="text/css">
+<link rel="stylesheet" href="node_modules/prismjs/themes/prism.css" type="text/css">
+<link rel="stylesheet" href="node_modules/prismjs/plugins/previewers/prism-previewers.css" type="text/css">
+<link rel="stylesheet" href="src/lib/jquery-colorbox/css/colorbox.css" type="text/css">
+<link rel="stylesheet" href="src/css/mdwiki.css" type="text/css">
+<script type="text/javascript" src="node_modules/jquery/dist/jquery.js"></script>
+<script type="text/javascript" src="node_modules/bootstrap/dist/js/bootstrap.js"></script>
+<script type="text/javascript" src="node_modules/prismjs/prism.js"></script>
+<script type="text/javascript" src="src/_compiled/js/prism-ext.js"></script>
+<script type="text/javascript" src="node_modules/jquery-colorbox/jquery.colorbox.js"></script>
+<script type="text/javascript" src="node_modules/marked/lib/marked.js"></script>
+<script type="text/javascript" src="src/_compiled/js/mdwiki.js"></script>
+<script type="text/javascript">$.md.logThreshold = $.md.loglevel.DEBUG;</script>
+  </head>
+  <body>
+    <noscript>
+        This website requires Javascript to be enabled. Please turn on Javascript
+        and reload the page.
+    </noscript>
+
+    <div id="md-all"><div id="md-menu">
+
+<div id="md-main-navbar" class="navbar navbar-default navbar-fixed-top" role="navigation"><div class="navbar-header"><button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-ex1-collapse"><span class="sr-only">Toggle navigation</span><span class="icon-bar"></span><span class="icon-bar"></span><span class="icon-bar"></span></button><a class="navbar-brand" href="#"></a></div><div class="collapse navbar-collapse navbar-ex1-collapse"><ul class="nav navbar-nav"><ul class="nav navbar-nav navbar-right"></ul><li class="active"><a href="#!index.md">Index</a></li><li><a href="#!cheatsheet.md">Cheatsheet</a></li></ul></div></div></div><div class="container" id="md-body-container"><div class="row" id="md-body-row"><div id="md-body" style="margin-top: 70px;"><div class="container" id="md-title-container"><div class="row" id="md-title-row"><div id="md-title" class="col-md-12"><div class="page-header"><h1 id="mdwiki">MDwiki</h1></div></div></div></div><div class="container" id="md-menu-container"><div class="row" id="md-menu-row"></div></div><div class="container" id="md-content-container"><div class="row" id="md-content-row"><div id="md-content" class="col-md-12">
+<p><div class="md-text">100% static single file CMS/Wiki done purely with client-side Javascript and HTML5.</div></p>
+<h2 id="see-httpwwwmdwikiinfo-for-more-info-and-documentation" class="md-inpage-anchor">See <a href="http://www.mdwiki.info">http://www.mdwiki.info</a> for more info and documentation.<span class="anchor-highlight" style="display: none;"><a href="#!./index.md#See_http://www.mdwiki.info_for_more_info_and_documentation.">?</a></span></h2>
+<h2 id="-this-fork-of-original-project-is-currently-only-for-experiments-and-not-for-production-use-" class="md-inpage-anchor">!! This fork of original project is currently only for experiments and not for production use !!<span class="anchor-highlight" style="display: none;"><a href="#!./index.md#!!_This_fork_of_original_project_is_currently_only_for_experiments_and_not_for_production_use_!!">?</a></span></h2>
+<h2 id="download" class="md-inpage-anchor">Download<span class="anchor-highlight" style="display: none;"><a href="#!./index.md#Download">?</a></span></h2>
+<p><div class="md-text">See <a href="https://github.com/Dynalon/mdwiki/releases">https://github.com/Dynalon/mdwiki/releases</a> for original project and readily precompiled releases.</div></p>
+<h2 id="how-to-build-from-source" class="md-inpage-anchor">How to build from source<span class="anchor-highlight" style="display: none;"><a href="#!./index.md#How_to_build_from_source">?</a></span></h2>
+<p><div class="md-text">(applies to this branch, others may differ)</div></p>
+<ol>
+<li><p><div class="md-text">Install node.js &gt;= 16.0.0 and npm (if not included)</div></p>
+</li>
+<li><p><div class="md-text">Clone the mdwiki repo</div></p>
+</li>
+<li><p><div class="md-text">Install deps and build MDwiki:</div></p>
+<pre class="language-bash" tabindex="0"><code class="language-bash"> <span class="token function">npm</span> <span class="token function">install</span>
+ <span class="token function">npm</span> update
+ ./node_modules/.bin/grunt</code></pre>
+<p><div class="md-text"> To get unminified source code compiled to <code>dist/mdwiki-debug.html</code>, as well as auto file watching and livereload support. Symlink the development mdwiki file into your webroot for testing.</div></p>
+</li>
+<li><p><div class="md-text">Find the <code>mdwiki.html</code> in the <code>dist/</code> folder</div></p>
+</li>
+<li><p><div class="md-text">Development server</div></p>
+<p><div class="md-text"> For loqading of development server, use</div></p>
+<pre class="language-bash" tabindex="0"><code class="language-bash"> ./node_modules/.bin/grunt serve</code></pre>
+</li>
+<li><p><div class="md-text">Release</div></p>
+<p><div class="md-text"> For creating release files, use</div></p>
+<pre class="language-bash" tabindex="0"><code class="language-bash"> ./node_modules/.bin/grunt release</code></pre>
+<p><div class="md-text"> Files will be created in <code>release</code> folder</div></p>
+</li>
+</ol>
+</div></div></div></div></div></div><hr style="position: relative; margin-top: 1em;"><div class="scontainer" style="position: relative; margin-top: 1em;"><div class="pull-right md-copyright-footer"> <span id="md-footer-additional">All content and images © by John Doe</span>Website generated with <a href="http://www.mdwiki.info">MDwiki</a> © Timo Dörr and contributors. </div></div></div>
+  <script src="//localhost:35729/livereload.js?snipver=1" async="" defer=""></script>
+
+<div id="cboxOverlay" style="display: none;"></div><div id="colorbox" class="" role="dialog" tabindex="-1" style="display: none;"><div id="cboxWrapper"><div><div id="cboxTopLeft" style="float: left;"></div><div id="cboxTopCenter" style="float: left;"></div><div id="cboxTopRight" style="float: left;"></div></div><div style="clear: left;"><div id="cboxMiddleLeft" style="float: left;"></div><div id="cboxContent" style="float: left;"><div id="cboxTitle" style="float: left;"></div><div id="cboxCurrent" style="float: left;"></div><button type="button" id="cboxPrevious"></button><button type="button" id="cboxNext"></button><button type="button" id="cboxSlideshow"></button><div id="cboxLoadingOverlay" style="float: left;"></div><div id="cboxLoadingGraphic" style="float: left;"></div></div><div id="cboxMiddleRight" style="float: left;"></div></div><div style="clear: left;"><div id="cboxBottomLeft" style="float: left;"></div><div id="cboxBottomCenter" style="float: left;"></div><div id="cboxBottomRight" style="float: left;"></div></div></div><div style="position: absolute; width: 9999px; visibility: hidden; display: none; max-width: none;"></div></div><span id="start-tests" style="display: none;"></span></body></html>

--- a/tests/crappy_tests/index.marked-3.0.8.html
+++ b/tests/crappy_tests/index.marked-3.0.8.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html><html class=""><!--
+   This is MDwiki v0.6.6 in debug mode
+   (C) 2013 by Timo Dörr and contributors. This software is licensed
+   under the terms of the GPLv3 with additional terms applied.
+   See https://github.com/Dynalon/mdwiki/blob/0.6.x/LICENSE.txt for more detail.
+   See https://github.com/Dynalon/mdwiki.git for a copy of the source code.
+--><head>
+    <title>MDwiki</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="fragment" content="!">
+    <link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
+    <meta charset="UTF-8">
+<link rel="stylesheet" href="node_modules/bootstrap/dist/css/bootstrap.css" type="text/css">
+<link rel="stylesheet" href="node_modules/prismjs/themes/prism.css" type="text/css">
+<link rel="stylesheet" href="node_modules/prismjs/plugins/previewers/prism-previewers.css" type="text/css">
+<link rel="stylesheet" href="src/lib/jquery-colorbox/css/colorbox.css" type="text/css">
+<link rel="stylesheet" href="src/css/mdwiki.css" type="text/css">
+<script type="text/javascript" src="node_modules/jquery/dist/jquery.js"></script>
+<script type="text/javascript" src="node_modules/bootstrap/dist/js/bootstrap.js"></script>
+<script type="text/javascript" src="node_modules/prismjs/prism.js"></script>
+<script type="text/javascript" src="src/_compiled/js/prism-ext.js"></script>
+<script type="text/javascript" src="node_modules/jquery-colorbox/jquery.colorbox.js"></script>
+<script type="text/javascript" src="node_modules/marked/lib/marked.js"></script>
+<script type="text/javascript" src="src/_compiled/js/mdwiki.js"></script>
+<script type="text/javascript">$.md.logThreshold = $.md.loglevel.DEBUG;</script>
+  </head>
+  <body>
+    <noscript>
+        This website requires Javascript to be enabled. Please turn on Javascript
+        and reload the page.
+    </noscript>
+
+    <div id="md-all"><div id="md-menu">
+
+<div id="md-main-navbar" class="navbar navbar-default navbar-fixed-top" role="navigation"><div class="navbar-header"><button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-ex1-collapse"><span class="sr-only">Toggle navigation</span><span class="icon-bar"></span><span class="icon-bar"></span><span class="icon-bar"></span></button><a class="navbar-brand" href="#"></a></div><div class="collapse navbar-collapse navbar-ex1-collapse"><ul class="nav navbar-nav"><ul class="nav navbar-nav navbar-right"></ul><li class="active"><a href="#!index.md">Index</a></li><li><a href="#!cheatsheet.md">Cheatsheet</a></li></ul></div></div></div><div class="container" id="md-body-container"><div class="row" id="md-body-row"><div id="md-body" style="margin-top: 70px;"><div class="container" id="md-title-container"><div class="row" id="md-title-row"><div id="md-title" class="col-md-12"><div class="page-header"><h1 id="mdwiki">MDwiki</h1></div></div></div></div><div class="container" id="md-menu-container"><div class="row" id="md-menu-row"></div></div><div class="container" id="md-content-container"><div class="row" id="md-content-row"><div id="md-content" class="col-md-12">
+<p><div class="md-text">100% static single file CMS/Wiki done purely with client-side Javascript and HTML5.</div></p>
+<h2 id="see-httpwwwmdwikiinfo-for-more-info-and-documentation" class="md-inpage-anchor">See <a href="http://www.mdwiki.info">http://www.mdwiki.info</a> for more info and documentation.<span class="anchor-highlight" style="display: none;"><a href="#!./index.md#See_http://www.mdwiki.info_for_more_info_and_documentation.">?</a></span></h2>
+<h2 id="-this-fork-of-original-project-is-currently-only-for-experiments-and-not-for-production-use-" class="md-inpage-anchor">!! This fork of original project is currently only for experiments and not for production use !!<span class="anchor-highlight" style="display: none;"><a href="#!./index.md#!!_This_fork_of_original_project_is_currently_only_for_experiments_and_not_for_production_use_!!">?</a></span></h2>
+<h2 id="download" class="md-inpage-anchor">Download<span class="anchor-highlight" style="display: none;"><a href="#!./index.md#Download">?</a></span></h2>
+<p><div class="md-text">See <a href="https://github.com/Dynalon/mdwiki/releases">https://github.com/Dynalon/mdwiki/releases</a> for original project and readily precompiled releases.</div></p>
+<h2 id="how-to-build-from-source" class="md-inpage-anchor">How to build from source<span class="anchor-highlight" style="display: none;"><a href="#!./index.md#How_to_build_from_source">?</a></span></h2>
+<p><div class="md-text">(applies to this branch, others may differ)</div></p>
+<ol>
+<li><p><div class="md-text">Install node.js &gt;= 16.0.0 and npm (if not included)</div></p>
+</li>
+<li><p><div class="md-text">Clone the mdwiki repo</div></p>
+</li>
+<li><p><div class="md-text">Install deps and build MDwiki:</div></p>
+<pre class="language-bash" tabindex="0"><code class="language-bash"><span class="token function">npm</span> <span class="token function">install</span>
+<span class="token function">npm</span> update
+./node_modules/.bin/grunt
+</code></pre>
+<p><div class="md-text"> To get unminified source code compiled to <code>dist/mdwiki-debug.html</code>, as well as auto file watching and livereload support. Symlink the development mdwiki file into your webroot for testing.</div></p>
+</li>
+<li><p><div class="md-text">Find the <code>mdwiki.html</code> in the <code>dist/</code> folder</div></p>
+</li>
+<li><p><div class="md-text">Development server</div></p>
+<p><div class="md-text"> For loqading of development server, use</div></p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">./node_modules/.bin/grunt serve
+</code></pre>
+</li>
+<li><p><div class="md-text">Release</div></p>
+<p><div class="md-text"> For creating release files, use</div></p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">./node_modules/.bin/grunt release
+</code></pre>
+<p><div class="md-text"> Files will be created in <code>release</code> folder</div></p>
+</li>
+</ol>
+</div></div></div></div></div></div><hr style="position: relative; margin-top: 1em;"><div class="scontainer" style="position: relative; margin-top: 1em;"><div class="pull-right md-copyright-footer"> <span id="md-footer-additional">All content and images © by John Doe</span>Website generated with <a href="http://www.mdwiki.info">MDwiki</a> © Timo Dörr and contributors. </div></div></div>
+  <script src="//localhost:35729/livereload.js?snipver=1" async="" defer=""></script>
+
+<div id="cboxOverlay" style="display: none;"></div><div id="colorbox" class="" role="dialog" tabindex="-1" style="display: none;"><div id="cboxWrapper"><div><div id="cboxTopLeft" style="float: left;"></div><div id="cboxTopCenter" style="float: left;"></div><div id="cboxTopRight" style="float: left;"></div></div><div style="clear: left;"><div id="cboxMiddleLeft" style="float: left;"></div><div id="cboxContent" style="float: left;"><div id="cboxTitle" style="float: left;"></div><div id="cboxCurrent" style="float: left;"></div><button type="button" id="cboxPrevious"></button><button type="button" id="cboxNext"></button><button type="button" id="cboxSlideshow"></button><div id="cboxLoadingOverlay" style="float: left;"></div><div id="cboxLoadingGraphic" style="float: left;"></div></div><div id="cboxMiddleRight" style="float: left;"></div></div><div style="clear: left;"><div id="cboxBottomLeft" style="float: left;"></div><div id="cboxBottomCenter" style="float: left;"></div><div id="cboxBottomRight" style="float: left;"></div></div></div><div style="position: absolute; width: 9999px; visibility: hidden; display: none; max-width: none;"></div></div><span id="start-tests" style="display: none;"></span></body></html>


### PR DESCRIPTION
This upgrades the marked.js node package as far as possible with minor rendering changes. 

It addresses one of two identified security issues with the package; the other is addressed in marked.js 4.0.10. Versions of marked.js 4.* and later fail to render due to a 404 that needs further debugging.